### PR TITLE
force 'dtype' to be the same as that of the input array in '_oneprojector_[di]'

### DIFF
--- a/spgl1/spgl1.py
+++ b/spgl1/spgl1.py
@@ -94,7 +94,7 @@ def _printf(fid, message):
 
 def _oneprojector_i(b, tau):
     n = b.size
-    x = np.zeros(n)
+    x = np.zeros(n, dtype=b.dtype)
     bNorm = np.linalg.norm(b, 1)
 
     if tau >= bNorm:
@@ -120,7 +120,7 @@ def _oneprojector_i(b, tau):
 
 def _oneprojector_d(b, d, tau):
     n = b.size
-    x = np.zeros(n)
+    x = np.zeros(n, dtype=b.dtype)
 
     if tau >= np.linalg.norm(d*b, 1):
         x = b.copy()


### PR DESCRIPTION
I encounter the problem that I used arrays of float32 as the input. The auxiliary arrays created inside spgl1 become float64. The issue probably would be more prominent when the complex-value array is in place. 