### PR TITLE
Add L-BFGS hybrid mode to SPGL1 solver

### DIFF
--- a/pytests/test_hybrid_mode.py
+++ b/pytests/test_hybrid_mode.py
@@ -1,0 +1,245 @@
+"""Test hybrid mode functionality."""
+import numpy as np
+import pytest
+from spgl1 import spgl1, spg_bpdn, spg_lasso
+from spgl1.lbfgs import lbfgs_init, lbfgs_update, lbfgs_hprod, lbfgs_bprod
+
+
+class TestLBFGSBasics:
+    """Test L-BFGS data structure and operations."""
+
+    def test_init(self):
+        """Test L-BFGS initialization."""
+        n, k = 100, 8
+        H = lbfgs_init(n, k, dscale=1e-3)
+        assert H.jMax == k
+        assert H.S.shape == (n, k)
+        assert H.Y.shape == (n, k)
+        assert H.gamma == 1e-3
+        assert H.delta == pytest.approx(1.0 / 1e-3)
+        assert H.rank == 0
+        assert not np.any(H.valid)
+
+    def test_hprod_no_history(self):
+        """H*g with no history should return gamma * g."""
+        n = 50
+        H = lbfgs_init(n, k=5, dscale=2.0)
+        g = np.random.randn(n)
+        p = lbfgs_hprod(H, g)
+        np.testing.assert_allclose(p, 2.0 * g)
+
+    def test_bprod_no_history(self):
+        """B*g with no history should return delta * g."""
+        n = 50
+        H = lbfgs_init(n, k=5, dscale=2.0)
+        g = np.random.randn(n)
+        p = lbfgs_bprod(H, g)
+        np.testing.assert_allclose(p, 0.5 * g)
+
+    def test_update_and_hprod(self):
+        """Test update followed by H*g produces valid output."""
+        np.random.seed(100)
+        n = 30
+        H = lbfgs_init(n, k=5, dscale=1e-3)
+
+        # Create a simple quadratic: f(x) = 0.5*x'Qx, g = Qx
+        Q = np.eye(n) + 0.1 * np.random.randn(n, n)
+        Q = Q.T @ Q  # Make SPD
+
+        x = np.random.randn(n)
+        g1 = Q @ x
+        p = -g1  # Steepest descent direction
+        step = 0.5
+        x_new = x + step * p
+        g2 = Q @ x_new
+
+        noup = lbfgs_update(H, step, p, g1, g2)
+        assert H.rank >= 0
+
+        # H*g should produce a valid vector
+        d = lbfgs_hprod(H, g2)
+        assert d.shape == (n,)
+        assert np.all(np.isfinite(d))
+
+    def test_update_curvature_skip(self):
+        """Test that updates with bad curvature are handled."""
+        n = 20
+        H = lbfgs_init(n, k=3, dscale=1.0)
+
+        # Create a case where curvature condition fails:
+        # gtp2 <= 0.91 * gtp1 means the gradient didn't decrease enough
+        # along the search direction. Use p = -g1 (descent dir) and g2 = g1
+        # so gtp1 < 0 and gtp2 = gtp1. Then gtp2 <= 0.91*gtp1 means
+        # gtp1 <= 0.91*gtp1 → 0.09*gtp1 <= 0, true since gtp1 < 0.
+        p = np.array([1.0] * n)
+        g1 = -p  # gtp1 = g1'*p = -n
+        g2 = g1.copy()  # gtp2 = -n also, so gtp2 <= 0.91*gtp1 → -n <= -0.91*n ✓
+        noup = lbfgs_update(H, 1.0, p, g1, g2)
+        assert noup  # Should skip
+        assert H.status == 2
+
+    def test_multiple_updates_circular_buffer(self):
+        """Test that circular buffer wraps correctly."""
+        np.random.seed(102)
+        n = 20
+        k = 3
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) * 2.0
+        x = np.random.randn(n)
+
+        for i in range(10):
+            g1 = Q @ x
+            p = -g1
+            step = 0.3
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        # Should still produce valid results
+        g = Q @ x
+        d = lbfgs_hprod(H, g)
+        assert np.all(np.isfinite(d))
+        assert H.rank <= k
+
+    def test_hprod_descent_direction(self):
+        """H*(-g) should generally be a descent direction."""
+        np.random.seed(103)
+        n = 30
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) + 0.5 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
+
+        # Build up some history
+        for i in range(5):
+            g1 = Q @ x
+            p = -g1
+            step = 0.1
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        g = Q @ x
+        d = lbfgs_hprod(H, -g)
+
+        # d should be a descent direction: g'*d < 0
+        assert g @ d < 0, f"Not a descent direction: g'*d = {g @ d}"
+
+
+class TestHybridModeBasics:
+    """Test hybrid mode integration in spgl1."""
+
+    def test_hybrid_mode_runs(self):
+        """Hybrid mode should run without errors on real L1 problems."""
+        np.random.seed(200)
+        m, n = 100, 200
+        A = np.random.randn(m, n)
+        x_true = np.zeros(n)
+        x_true[:5] = np.random.randn(5)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        sigma = 0.1 * np.linalg.norm(b)
+
+        x, r, g, info = spg_bpdn(A, b, sigma, hybrid_mode=True, verbosity=0)
+        assert info['stat'] in [1, 2, 3, 4, 5]
+        assert np.all(np.isfinite(x))
+
+    def test_hybrid_same_result_as_standard(self):
+        """Hybrid should give similar solution to standard mode."""
+        np.random.seed(201)
+        m, n = 100, 200
+        A = np.random.randn(m, n)
+        x_true = np.zeros(n)
+        x_true[:5] = np.random.randn(5)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        sigma = 0.1 * np.linalg.norm(b)
+
+        x_std, _, _, info_std = spg_bpdn(A, b, sigma, verbosity=0)
+        x_hyb, _, _, info_hyb = spg_bpdn(A, b, sigma, hybrid_mode=True, verbosity=0)
+
+        # Both should converge
+        assert info_std['stat'] in [1, 2, 3, 4]
+        assert info_hyb['stat'] in [1, 2, 3, 4]
+
+        # Solutions should have similar objective
+        np.testing.assert_allclose(info_std['rnorm'], info_hyb['rnorm'], rtol=0.1)
+
+    def test_hybrid_lasso(self):
+        """Hybrid mode with LASSO (fixed tau)."""
+        np.random.seed(202)
+        m, n = 100, 200
+        A = np.random.randn(m, n)
+        x_true = np.zeros(n)
+        x_true[:5] = np.random.randn(5)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        tau = np.linalg.norm(x_true, 1) * 1.5
+
+        x, r, g, info = spgl1(A, b, tau=tau, hybrid_mode=True, verbosity=0)
+        assert info['stat'] in [1, 2, 3, 4]
+        assert np.all(np.isfinite(x))
+
+    def test_hybrid_rejects_complex(self):
+        """Hybrid mode should reject complex problems."""
+        m, n = 50, 100
+        A = np.random.randn(m, n) + 1j * np.random.randn(m, n)
+        b = np.random.randn(m) + 1j * np.random.randn(m)
+        with pytest.raises(ValueError, match="Hybrid mode only applies"):
+            spgl1(A, b, tau=1.0, hybrid_mode=True, iscomplex=True, verbosity=0)
+
+    def test_hybrid_default_off(self):
+        """Hybrid mode should be off by default."""
+        np.random.seed(204)
+        m, n = 50, 100
+        A = np.random.randn(m, n)
+        b = np.random.randn(m)
+        x, r, g, info = spgl1(A, b, tau=1.0, verbosity=0)
+        assert info['stat'] in range(1, 12)
+
+
+class TestProductB:
+    """Test productB transformation."""
+
+    def test_forward_dimensions(self):
+        """Forward: d -> d+1."""
+        from spgl1.productB import product_b, compute_sqrt_vectors
+        d = 10
+        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        x = np.random.randn(d)
+        y = product_b(x, 0, sqrt1, sqrt2)
+        assert y.shape == (d + 1,)
+        assert np.all(np.isfinite(y))
+
+    def test_transpose_dimensions(self):
+        """Transpose: d+1 -> d."""
+        from spgl1.productB import product_b, compute_sqrt_vectors
+        d = 10
+        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        x = np.random.randn(d + 1)
+        y = product_b(x, 1, sqrt1, sqrt2)
+        assert y.shape == (d,)
+        assert np.all(np.isfinite(y))
+
+    def test_adjoint_property(self):
+        """<Bx, y> == <x, B'y> (adjoint property)."""
+        from spgl1.productB import product_b, compute_sqrt_vectors
+        np.random.seed(300)
+        d = 20
+        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+
+        x = np.random.randn(d)
+        y = np.random.randn(d + 1)
+
+        Bx = product_b(x, 0, sqrt1, sqrt2)
+        Bty = product_b(y, 1, sqrt1, sqrt2)
+
+        lhs = Bx @ y
+        rhs = x @ Bty
+        np.testing.assert_allclose(lhs, rhs, rtol=1e-12)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/pytests/test_hybrid_mode.py
+++ b/pytests/test_hybrid_mode.py
@@ -107,7 +107,7 @@ class TestLBFGSBasics:
         np.testing.assert_allclose(p, 0.5 * g)
 
     def test_update_and_hprod(self):
-        """Test update followed by H*g produces valid output."""
+        """Test update stores vectors and changes H*g output."""
         np.random.seed(100)
         n = 30
         H = lbfgs_init(n, k=5, dscale=1e-3)
@@ -122,12 +122,28 @@ class TestLBFGSBasics:
         x_new = x + step * p
         g2 = Q @ x_new
 
-        noup = lbfgs_update(H, step, p, g1, g2)
-        assert H.rank >= 0
+        # Before update: H*g = gamma * g (no history)
+        g_test = np.random.randn(n)
+        hg_before = lbfgs_hprod(H, g_test)
+        np.testing.assert_allclose(hg_before, H.gamma * g_test)
 
-        d = lbfgs_hprod(H, g2)
-        assert d.shape == (n,)
-        assert np.all(np.isfinite(d))
+        noup = lbfgs_update(H, step, p, g1, g2)
+
+        # After update: rank increased, gamma changed, H*g differs
+        assert not noup, "Update should not be skipped for valid curvature"
+        assert H.rank == 1, "Rank should be 1 after first update"
+        assert H.status in [0, 1], "Status should be 0 (update) or 1 (damped)"
+
+        # Verify stored vectors
+        s_stored = step * p
+        y_stored = g2 - g1
+        # The update may apply damping, so just check s is stored correctly
+        np.testing.assert_allclose(H.S[:, H.jNew], s_stored)
+
+        # H*g should now differ from gamma*g
+        hg_after = lbfgs_hprod(H, g_test)
+        assert not np.allclose(hg_after, H.gamma * g_test), \
+            "H*g should differ from gamma*g after update"
 
     def test_update_curvature_skip(self):
         """Test that updates with bad curvature are handled."""
@@ -143,7 +159,7 @@ class TestLBFGSBasics:
         assert H.status == 2
 
     def test_multiple_updates_circular_buffer(self):
-        """Test that circular buffer wraps correctly."""
+        """Test that circular buffer wraps and maintains only k newest pairs."""
         np.random.seed(102)
         n = 20
         k = 3
@@ -152,6 +168,8 @@ class TestLBFGSBasics:
         Q = np.eye(n) * 2.0
         x = np.random.randn(n)
 
+        # Store the step vectors for verification
+        all_s_vectors = []
         for i in range(10):
             g1 = Q @ x
             p = -g1
@@ -159,12 +177,30 @@ class TestLBFGSBasics:
             x_new = x + step * p
             g2 = Q @ x_new
             lbfgs_update(H, step, p, g1, g2)
+            all_s_vectors.append(step * p)
             x = x_new
 
+        # After 10 updates with k=3: rank should be exactly k
+        assert H.rank == k, f"Rank should be {k}, got {H.rank}"
+
+        # Buffer should contain the 3 most recent s vectors
+        # Find which slots are valid
+        valid_slots = np.where(H.valid)[0]
+        assert len(valid_slots) == k
+
+        # The newest 3 s vectors should be in the buffer
+        newest_s = all_s_vectors[-k:]
+        stored_s = [H.S[:, slot] for slot in valid_slots]
+
+        # Each of the newest s vectors should match one stored vector
+        for s_new in newest_s:
+            found = any(np.allclose(s_new, s_stored) for s_stored in stored_s)
+            assert found, "Newest s vector not found in buffer"
+
+        # Verify H*g still produces descent direction
         g = Q @ x
-        d = lbfgs_hprod(H, g)
-        assert np.all(np.isfinite(d))
-        assert H.rank <= k
+        d = lbfgs_hprod(H, -g)
+        assert g @ d < 0, "Should still produce descent direction"
 
     def test_hprod_descent_direction(self):
         """H*(-g) should generally be a descent direction."""
@@ -299,22 +335,58 @@ class TestLBFGSBasics:
         np.testing.assert_allclose(bhg, g, rtol=1e-10,
                                    err_msg="B*H*g != g (B and H not inverses)")
 
-    def test_damped_update_triggered(self):
-        """Verify damped BFGS update triggers when yts < 0.2 * sbs."""
+    def test_damped_update_status_values(self):
+        """Verify status correctly reflects update type (normal=0, damped=1, skip=2).
+
+        The L-BFGS update has three outcomes:
+        - status=0: Normal update (curvature good, no damping needed)
+        - status=1: Damped update (curvature good, but yts < 0.2*sbs)
+        - status=2: Skipped (curvature condition failed: gtp2 <= 0.91*gtp1)
+        """
         np.random.seed(108)
         n = 20
-        H = lbfgs_init(n, k=5, dscale=1.0)
+        k = 5
 
+        # Test 1: Normal update on well-conditioned quadratic
+        H = lbfgs_init(n, k, dscale=1.0)
         Q = np.eye(n) * 2.0
         x = np.random.randn(n)
         g1 = Q @ x
         p = -g1
-        step = 0.1
+        step = 0.3  # Larger step ensures good curvature
         x_new = x + step * p
         g2 = Q @ x_new
+
         noup = lbfgs_update(H, step, p, g1, g2)
-        assert not noup
-        assert H.status in [0, 1]
+        assert not noup, "Should not skip update"
+        assert H.status in [0, 1], f"Status should be 0 or 1, got {H.status}"
+
+        # Test 2: Verify skip condition (status=2)
+        H2 = lbfgs_init(n, k, dscale=1.0)
+        p = np.ones(n)
+        g1 = -p  # gtp1 = -n
+        g2 = g1.copy()  # gtp2 = -n, so gtp2 <= 0.91*gtp1
+        noup = lbfgs_update(H2, 1.0, p, g1, g2)
+        assert noup, "Should skip update"
+        assert H2.status == 2, f"Status should be 2 (skip), got {H2.status}"
+
+        # Test 3: After multiple updates, verify update still works
+        H3 = lbfgs_init(n, k, dscale=1e-3)
+        x = np.random.randn(n)
+        statuses = []
+        for i in range(5):
+            g1 = Q @ x
+            p = -g1
+            step = 0.2
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H3, step, p, g1, g2)
+            statuses.append(H3.status)
+            x = x_new
+
+        # All should be successful updates (0 or 1)
+        assert all(s in [0, 1] for s in statuses), \
+            f"All statuses should be 0 or 1, got {statuses}"
 
 
 # =========================================================================
@@ -357,7 +429,7 @@ class TestHybridModeBasics:
         np.testing.assert_allclose(info_std['rnorm'], info_hyb['rnorm'], rtol=0.1)
 
     def test_hybrid_lasso(self):
-        """Hybrid mode with LASSO (fixed tau)."""
+        """Hybrid mode with LASSO (fixed tau) produces valid L1-constrained solution."""
         np.random.seed(202)
         m, n = 100, 200
         A = np.random.randn(m, n)
@@ -367,8 +439,25 @@ class TestHybridModeBasics:
         tau = np.linalg.norm(x_true, 1) * 1.5
 
         x, r, g, info = spgl1(A, b, tau=tau, hybrid_mode=True, verbosity=0)
-        assert info['stat'] in [1, 2, 3, 4]
+
+        # Should converge
+        assert info['stat'] in [1, 2, 3, 4], f"Did not converge: stat={info['stat']}"
         assert np.all(np.isfinite(x))
+
+        # L1 norm should respect constraint (within tolerance)
+        x_norm1 = np.linalg.norm(x, 1)
+        assert x_norm1 <= tau * 1.01, f"L1 norm {x_norm1} exceeds tau {tau}"
+
+        # Residual should be reasonable
+        r_computed = b - A @ x
+        np.testing.assert_allclose(r, r_computed, rtol=1e-10)
+
+        # Solution should recover some of the true signal structure
+        # (at least the largest components should be in the right places)
+        top5_true = np.argsort(np.abs(x_true))[-5:]
+        top5_recovered = np.argsort(np.abs(x))[-5:]
+        overlap = len(set(top5_true) & set(top5_recovered))
+        assert overlap >= 3, f"Poor support recovery: only {overlap}/5 overlap"
 
     def test_hybrid_rejects_complex(self):
         """Hybrid mode should reject complex problems."""
@@ -379,13 +468,28 @@ class TestHybridModeBasics:
             spgl1(A, b, tau=1.0, hybrid_mode=True, iscomplex=True, verbosity=0)
 
     def test_hybrid_default_off(self):
-        """Hybrid mode should be off by default."""
+        """Verify hybrid_mode defaults to False and doesn't affect standard mode."""
         np.random.seed(204)
         m, n = 50, 100
         A = np.random.randn(m, n)
-        b = np.random.randn(m)
-        x, r, g, info = spgl1(A, b, tau=1.0, verbosity=0)
-        assert info['stat'] in range(1, 12)
+        x_true = np.zeros(n)
+        x_true[:3] = np.random.randn(3)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        sigma = 0.1 * np.linalg.norm(b)
+
+        # Run without specifying hybrid_mode (should default to False)
+        x_default, _, _, info_default = spg_bpdn(A, b, sigma, verbosity=0)
+
+        # Run with explicit hybrid_mode=False
+        x_explicit, _, _, info_explicit = spg_bpdn(A, b, sigma, hybrid_mode=False, verbosity=0)
+
+        # Both should produce identical results (same code path)
+        np.testing.assert_allclose(x_default, x_explicit, rtol=1e-12,
+                                   err_msg="Default should equal explicit hybrid_mode=False")
+        assert info_default['niters'] == info_explicit['niters'], \
+            "Iteration counts should match"
+        assert info_default['stat'] == info_explicit['stat'], \
+            "Exit status should match"
 
     def test_hybrid_multiple_seeds(self):
         """Hybrid mode should work across different random problems."""

--- a/pytests/test_hybrid_mode.py
+++ b/pytests/test_hybrid_mode.py
@@ -1,9 +1,77 @@
-"""Test hybrid mode functionality."""
+"""Test hybrid mode functionality.
+
+Tests L-BFGS infrastructure, hybrid mode integration, and productB transformation.
+Includes both pure-Python robustness tests and Octave cross-validation tests.
+"""
+import subprocess
+import tempfile
+from pathlib import Path
+
 import numpy as np
 import pytest
+from scipy.io import savemat, loadmat
+
 from spgl1 import spgl1, spg_bpdn, spg_lasso
 from spgl1.lbfgs import lbfgs_init, lbfgs_update, lbfgs_hprod, lbfgs_bprod
+from spgl1.productB import product_b, compute_sqrt_vectors
+from pytests.conftest import octave_available, MATLAB_SPGL_PATH
 
+
+def _run_octave_script(script, input_data, timeout=30):
+    """Run an Octave script with .mat file I/O.
+
+    Parameters
+    ----------
+    script : str
+        Octave script that loads 'input.mat' and saves results to 'output.mat'.
+    input_data : dict
+        Variables to save to input.mat.
+    timeout : int
+        Timeout in seconds.
+
+    Returns
+    -------
+    dict or None
+        Loaded output.mat contents, or None on failure.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_file = str(Path(tmpdir) / "input.mat")
+        output_file = str(Path(tmpdir) / "output.mat")
+
+        # Convert 1D arrays to column vectors for MATLAB
+        mat_data = {}
+        for k, v in input_data.items():
+            if isinstance(v, np.ndarray) and v.ndim == 1:
+                mat_data[k] = v.reshape(-1, 1)
+            else:
+                mat_data[k] = v
+        savemat(input_file, mat_data, format='5')
+
+        full_script = f"""
+        addpath('{MATLAB_SPGL_PATH}');
+        addpath(fullfile('{MATLAB_SPGL_PATH}', 'private'));
+        load('{input_file}');
+        {script}
+        save('-v7', '{output_file}');
+        """
+
+        try:
+            result = subprocess.run(
+                ["octave", "--quiet", "--eval", full_script],
+                capture_output=True, text=True, timeout=timeout
+            )
+            if result.returncode != 0:
+                print(f"Octave stderr: {result.stderr}")
+                return None
+            return loadmat(output_file)
+        except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+            print(f"Octave error: {e}")
+            return None
+
+
+# =========================================================================
+# Pure-Python L-BFGS tests
+# =========================================================================
 
 class TestLBFGSBasics:
     """Test L-BFGS data structure and operations."""
@@ -22,6 +90,7 @@ class TestLBFGSBasics:
 
     def test_hprod_no_history(self):
         """H*g with no history should return gamma * g."""
+        np.random.seed(50)
         n = 50
         H = lbfgs_init(n, k=5, dscale=2.0)
         g = np.random.randn(n)
@@ -30,6 +99,7 @@ class TestLBFGSBasics:
 
     def test_bprod_no_history(self):
         """B*g with no history should return delta * g."""
+        np.random.seed(51)
         n = 50
         H = lbfgs_init(n, k=5, dscale=2.0)
         g = np.random.randn(n)
@@ -42,13 +112,12 @@ class TestLBFGSBasics:
         n = 30
         H = lbfgs_init(n, k=5, dscale=1e-3)
 
-        # Create a simple quadratic: f(x) = 0.5*x'Qx, g = Qx
         Q = np.eye(n) + 0.1 * np.random.randn(n, n)
-        Q = Q.T @ Q  # Make SPD
+        Q = Q.T @ Q
 
         x = np.random.randn(n)
         g1 = Q @ x
-        p = -g1  # Steepest descent direction
+        p = -g1
         step = 0.5
         x_new = x + step * p
         g2 = Q @ x_new
@@ -56,7 +125,6 @@ class TestLBFGSBasics:
         noup = lbfgs_update(H, step, p, g1, g2)
         assert H.rank >= 0
 
-        # H*g should produce a valid vector
         d = lbfgs_hprod(H, g2)
         assert d.shape == (n,)
         assert np.all(np.isfinite(d))
@@ -66,16 +134,12 @@ class TestLBFGSBasics:
         n = 20
         H = lbfgs_init(n, k=3, dscale=1.0)
 
-        # Create a case where curvature condition fails:
-        # gtp2 <= 0.91 * gtp1 means the gradient didn't decrease enough
-        # along the search direction. Use p = -g1 (descent dir) and g2 = g1
-        # so gtp1 < 0 and gtp2 = gtp1. Then gtp2 <= 0.91*gtp1 means
-        # gtp1 <= 0.91*gtp1 → 0.09*gtp1 <= 0, true since gtp1 < 0.
+        # gtp1 = g1'*p = -n, gtp2 = -n, noup = (-n <= 0.91*(-n)) = (-n <= -0.91n) = True
         p = np.array([1.0] * n)
-        g1 = -p  # gtp1 = g1'*p = -n
-        g2 = g1.copy()  # gtp2 = -n also, so gtp2 <= 0.91*gtp1 → -n <= -0.91*n ✓
+        g1 = -p
+        g2 = g1.copy()
         noup = lbfgs_update(H, 1.0, p, g1, g2)
-        assert noup  # Should skip
+        assert noup
         assert H.status == 2
 
     def test_multiple_updates_circular_buffer(self):
@@ -97,7 +161,6 @@ class TestLBFGSBasics:
             lbfgs_update(H, step, p, g1, g2)
             x = x_new
 
-        # Should still produce valid results
         g = Q @ x
         d = lbfgs_hprod(H, g)
         assert np.all(np.isfinite(d))
@@ -114,7 +177,6 @@ class TestLBFGSBasics:
         Q = Q.T @ Q
         x = np.random.randn(n)
 
-        # Build up some history
         for i in range(5):
             g1 = Q @ x
             p = -g1
@@ -126,10 +188,138 @@ class TestLBFGSBasics:
 
         g = Q @ x
         d = lbfgs_hprod(H, -g)
-
-        # d should be a descent direction: g'*d < 0
         assert g @ d < 0, f"Not a descent direction: g'*d = {g @ d}"
 
+    def test_hprod_positive_definite(self):
+        """H should be positive definite: g'*H*g > 0 for any g != 0."""
+        np.random.seed(104)
+        n = 30
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) + 0.3 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
+
+        for i in range(5):
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        for trial in range(20):
+            g = np.random.randn(n)
+            d = lbfgs_hprod(H, g)
+            assert g @ d > 0, f"Lost positive definiteness at trial {trial}: g'*H*g = {g @ d}"
+
+    def test_hprod_symmetry(self):
+        """H should be symmetric: (H*g1)'*g2 == g1'*(H*g2)."""
+        np.random.seed(105)
+        n = 30
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) + 0.2 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
+
+        for i in range(4):
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        for trial in range(10):
+            v1 = np.random.randn(n)
+            v2 = np.random.randn(n)
+            d1 = lbfgs_hprod(H, v1)
+            d2 = lbfgs_hprod(H, v2)
+            lhs = d1 @ v2
+            rhs = v1 @ d2
+            rel_err = abs(lhs - rhs) / (abs(lhs) + 1e-15)
+            assert rel_err < 1e-10, f"Symmetry violation at trial {trial}: rel_err={rel_err}"
+
+    def test_hprod_linearity(self):
+        """H should be linear: H*(a*g1 + b*g2) == a*H*g1 + b*H*g2."""
+        np.random.seed(106)
+        n = 30
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) + 0.3 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
+
+        for i in range(4):
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        v1 = np.random.randn(n)
+        v2 = np.random.randn(n)
+        a, b = 2.3, -1.7
+        np.testing.assert_allclose(
+            lbfgs_hprod(H, a * v1 + b * v2),
+            a * lbfgs_hprod(H, v1) + b * lbfgs_hprod(H, v2),
+            rtol=1e-12
+        )
+
+    def test_bprod_hprod_inverse(self):
+        """B*H*g should approximately equal g (B = H^{-1})."""
+        np.random.seed(107)
+        n = 20
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) * 2.0
+        x = np.random.randn(n)
+
+        for i in range(5):
+            g1 = Q @ x
+            p = -g1
+            step = 0.1
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        g = np.random.randn(n)
+        hg = lbfgs_hprod(H, g)
+        bhg = lbfgs_bprod(H, hg)
+        np.testing.assert_allclose(bhg, g, rtol=1e-10,
+                                   err_msg="B*H*g != g (B and H not inverses)")
+
+    def test_damped_update_triggered(self):
+        """Verify damped BFGS update triggers when yts < 0.2 * sbs."""
+        np.random.seed(108)
+        n = 20
+        H = lbfgs_init(n, k=5, dscale=1.0)
+
+        Q = np.eye(n) * 2.0
+        x = np.random.randn(n)
+        g1 = Q @ x
+        p = -g1
+        step = 0.1
+        x_new = x + step * p
+        g2 = Q @ x_new
+        noup = lbfgs_update(H, step, p, g1, g2)
+        assert not noup
+        assert H.status in [0, 1]
+
+
+# =========================================================================
+# Hybrid mode integration tests
+# =========================================================================
 
 class TestHybridModeBasics:
     """Test hybrid mode integration in spgl1."""
@@ -161,11 +351,9 @@ class TestHybridModeBasics:
         x_std, _, _, info_std = spg_bpdn(A, b, sigma, verbosity=0)
         x_hyb, _, _, info_hyb = spg_bpdn(A, b, sigma, hybrid_mode=True, verbosity=0)
 
-        # Both should converge
         assert info_std['stat'] in [1, 2, 3, 4]
         assert info_hyb['stat'] in [1, 2, 3, 4]
 
-        # Solutions should have similar objective
         np.testing.assert_allclose(info_std['rnorm'], info_hyb['rnorm'], rtol=0.1)
 
     def test_hybrid_lasso(self):
@@ -199,13 +387,32 @@ class TestHybridModeBasics:
         x, r, g, info = spgl1(A, b, tau=1.0, verbosity=0)
         assert info['stat'] in range(1, 12)
 
+    def test_hybrid_multiple_seeds(self):
+        """Hybrid mode should work across different random problems."""
+        for seed in [300, 301, 302, 303, 304]:
+            np.random.seed(seed)
+            m, n = 80, 160
+            A = np.random.randn(m, n)
+            x_true = np.zeros(n)
+            x_true[:8] = np.random.randn(8)
+            b = A @ x_true + 0.01 * np.random.randn(m)
+            sigma = 0.15 * np.linalg.norm(b)
+
+            x, r, g, info = spg_bpdn(A, b, sigma, hybrid_mode=True, verbosity=0)
+            assert info['stat'] in [1, 2, 3, 4, 5], \
+                f"seed={seed}: stat={info['stat']}"
+            assert np.all(np.isfinite(x)), f"seed={seed}: non-finite x"
+
+
+# =========================================================================
+# ProductB tests
+# =========================================================================
 
 class TestProductB:
     """Test productB transformation."""
 
     def test_forward_dimensions(self):
         """Forward: d -> d+1."""
-        from spgl1.productB import product_b, compute_sqrt_vectors
         d = 10
         sqrt1, sqrt2 = compute_sqrt_vectors(d)
         x = np.random.randn(d)
@@ -215,7 +422,6 @@ class TestProductB:
 
     def test_transpose_dimensions(self):
         """Transpose: d+1 -> d."""
-        from spgl1.productB import product_b, compute_sqrt_vectors
         d = 10
         sqrt1, sqrt2 = compute_sqrt_vectors(d)
         x = np.random.randn(d + 1)
@@ -225,7 +431,6 @@ class TestProductB:
 
     def test_adjoint_property(self):
         """<Bx, y> == <x, B'y> (adjoint property)."""
-        from spgl1.productB import product_b, compute_sqrt_vectors
         np.random.seed(300)
         d = 20
         sqrt1, sqrt2 = compute_sqrt_vectors(d)
@@ -239,6 +444,395 @@ class TestProductB:
         lhs = Bx @ y
         rhs = x @ Bty
         np.testing.assert_allclose(lhs, rhs, rtol=1e-12)
+
+    def test_orthogonality(self):
+        """B'*B should be identity (orthogonal transformation)."""
+        np.random.seed(301)
+        d = 15
+        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+
+        # Build B'B explicitly via unit vectors
+        BtB = np.zeros((d, d))
+        for j in range(d):
+            ej = np.zeros(d)
+            ej[j] = 1.0
+            Bej = product_b(ej, 0, sqrt1, sqrt2)
+            for i in range(d):
+                ei = np.zeros(d)
+                ei[i] = 1.0
+                Bei = product_b(ei, 0, sqrt1, sqrt2)
+                BtB[i, j] = Bei @ Bej
+
+        np.testing.assert_allclose(BtB, np.eye(d), atol=1e-13)
+
+
+# =========================================================================
+# Octave cross-validation: L-BFGS operations
+# =========================================================================
+
+@pytest.mark.matlab
+@pytest.mark.skipif(not octave_available(), reason="Octave not available")
+class TestLBFGSVsOctave:
+    """Cross-validate L-BFGS operations against MATLAB/Octave."""
+
+    def _build_lbfgs_state(self, n, k, dscale, Q, x0, num_updates, step=0.1):
+        """Build L-BFGS state by running steepest descent updates.
+
+        Returns (H, x_final) after num_updates steepest descent steps.
+        """
+        H = lbfgs_init(n, k, dscale=dscale)
+        x = x0.copy()
+        for i in range(num_updates):
+            g1 = Q @ x
+            p = -g1
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+        return H, x
+
+    def test_hprod_after_updates(self):
+        """Compare H*g after a sequence of updates."""
+        np.random.seed(500)
+        n, k, dscale = 20, 5, 1e-3
+        Q = np.eye(n) * 2.0
+        x0 = np.random.randn(n)
+        g_test = np.random.randn(n)
+
+        H, _ = self._build_lbfgs_state(n, k, dscale, Q, x0, 4)
+        hg_py = lbfgs_hprod(H, g_test)
+        bg_py = lbfgs_bprod(H, g_test)
+
+        script = """
+        n = double(n); k = double(k); dscale = double(dscale);
+        Q = eye(n) * 2.0;
+        x = x0;
+        H = lbfgsinit(n, k, dscale);
+        for i = 1:4
+            g1 = Q * x;
+            p = -g1;
+            step = 0.1;
+            x_new = x + step * p;
+            g2 = Q * x_new;
+            [H, noup] = lbfgsupdate(H, step, p, g1, g2);
+            x = x_new;
+        end
+        hg_matlab = lbfgshprod(H, g_test);
+        bg_matlab = lbfgsbprod(H, g_test);
+        gamma_matlab = H.gamma;
+        delta_matlab = H.delta;
+        rank_matlab = H.rank;
+        """
+        out = _run_octave_script(script, {
+            'n': float(n), 'k': float(k), 'dscale': float(dscale),
+            'x0': x0, 'g_test': g_test
+        })
+        assert out is not None, "Octave script failed"
+
+        np.testing.assert_allclose(hg_py, out['hg_matlab'].flatten(),
+                                   rtol=1e-12, atol=1e-14,
+                                   err_msg="lbfgs_hprod mismatch vs MATLAB")
+        np.testing.assert_allclose(bg_py, out['bg_matlab'].flatten(),
+                                   rtol=1e-12, atol=1e-14,
+                                   err_msg="lbfgs_bprod mismatch vs MATLAB")
+        assert H.gamma == pytest.approx(float(out['gamma_matlab'].flatten()[0]), rel=1e-12)
+        assert H.delta == pytest.approx(float(out['delta_matlab'].flatten()[0]), rel=1e-12)
+        assert H.rank == int(out['rank_matlab'].flatten()[0])
+
+    def test_curvature_skip_matches(self):
+        """Verify curvature skip decision matches MATLAB."""
+        n = 10
+        H = lbfgs_init(n, k=3, dscale=1.0)
+        p = np.ones(n)
+        g1 = -p
+        g2 = g1.copy()
+        noup_py = lbfgs_update(H, 1.0, p, g1, g2)
+
+        script = """
+        n = double(n);
+        H = lbfgsinit(n, 3, 1.0);
+        p = ones(n, 1);
+        g1 = -p;
+        g2 = g1;
+        [H, noup] = lbfgsupdate(H, 1.0, p, g1, g2);
+        noup_matlab = double(noup);
+        status_matlab = H.status;
+        """
+        out = _run_octave_script(script, {'n': float(n)})
+        assert out is not None, "Octave script failed"
+
+        assert noup_py == bool(out['noup_matlab'].flatten()[0])
+        assert H.status == int(out['status_matlab'].flatten()[0])
+
+    def test_multiple_updates_match(self):
+        """Compare state after many updates (circular buffer wrapping)."""
+        np.random.seed(502)
+        n, k, dscale = 15, 3, 1e-3
+        Q = np.eye(n) * 3.0
+        x0 = np.random.randn(n)
+        g_test = np.random.randn(n)
+
+        # Python
+        H = lbfgs_init(n, k, dscale)
+        x = x0.copy()
+        noup_list_py = []
+        for i in range(8):
+            g1 = Q @ x
+            p = -g1
+            step = 0.1
+            x_new = x + step * p
+            g2 = Q @ x_new
+            noup = lbfgs_update(H, step, p, g1, g2)
+            noup_list_py.append(noup)
+            x = x_new
+        hg_py = lbfgs_hprod(H, g_test)
+
+        # Octave
+        script = """
+        n = double(n); k = double(k); dscale = double(dscale);
+        Q = eye(n) * 3.0;
+        x = x0;
+        H = lbfgsinit(n, k, dscale);
+        noup_list = zeros(8, 1);
+        for i = 1:8
+            g1 = Q * x;
+            p = -g1;
+            step = 0.1;
+            x_new = x + step * p;
+            g2 = Q * x_new;
+            [H, noup] = lbfgsupdate(H, step, p, g1, g2);
+            noup_list(i) = double(noup);
+            x = x_new;
+        end
+        hg_matlab = lbfgshprod(H, g_test);
+        gamma_matlab = H.gamma;
+        rank_matlab = H.rank;
+        """
+        out = _run_octave_script(script, {
+            'n': float(n), 'k': float(k), 'dscale': float(dscale),
+            'x0': x0, 'g_test': g_test
+        })
+        assert out is not None, "Octave script failed"
+
+        noup_list_mat = out['noup_list'].flatten().astype(bool).tolist()
+        assert noup_list_py == noup_list_mat, \
+            f"noup sequence mismatch: py={noup_list_py}, mat={noup_list_mat}"
+        np.testing.assert_allclose(hg_py, out['hg_matlab'].flatten(),
+                                   rtol=1e-12, atol=1e-14,
+                                   err_msg="hprod mismatch after 8 updates")
+        assert H.gamma == pytest.approx(float(out['gamma_matlab'].flatten()[0]), rel=1e-12)
+        assert H.rank == int(out['rank_matlab'].flatten()[0])
+
+    def test_damped_update_matches(self):
+        """Verify damped BFGS correction matches MATLAB."""
+        np.random.seed(503)
+        n, k, dscale = 15, 5, 1.0
+        Q = np.eye(n) * 2.0
+        x0 = np.random.randn(n)
+        g_test = np.random.randn(n)
+
+        # Python
+        H = lbfgs_init(n, k, dscale)
+        x = x0.copy()
+        statuses_py = []
+        for i in range(3):
+            g1 = Q @ x
+            p = -g1
+            step = 0.1
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            statuses_py.append(H.status)
+            x = x_new
+        hg_py = lbfgs_hprod(H, g_test)
+        bg_py = lbfgs_bprod(H, g_test)
+
+        # Octave
+        script = """
+        n = double(n); k = double(k); dscale = double(dscale);
+        Q = eye(n) * 2.0;
+        x = x0;
+        H = lbfgsinit(n, k, dscale);
+        statuses = zeros(3, 1);
+        for i = 1:3
+            g1 = Q * x;
+            p = -g1;
+            step = 0.1;
+            x_new = x + step * p;
+            g2 = Q * x_new;
+            [H, noup] = lbfgsupdate(H, step, p, g1, g2);
+            statuses(i) = H.status;
+            x = x_new;
+        end
+        hg_matlab = lbfgshprod(H, g_test);
+        bg_matlab = lbfgsbprod(H, g_test);
+        """
+        out = _run_octave_script(script, {
+            'n': float(n), 'k': float(k), 'dscale': float(dscale),
+            'x0': x0, 'g_test': g_test
+        })
+        assert out is not None, "Octave script failed"
+
+        statuses_mat = out['statuses'].flatten().astype(int).tolist()
+        assert statuses_py == statuses_mat, \
+            f"Status sequence mismatch: py={statuses_py}, mat={statuses_mat}"
+        np.testing.assert_allclose(hg_py, out['hg_matlab'].flatten(),
+                                   rtol=1e-12, atol=1e-14)
+        np.testing.assert_allclose(bg_py, out['bg_matlab'].flatten(),
+                                   rtol=1e-12, atol=1e-14)
+
+    def test_bprod_hprod_inverse_matches(self):
+        """Verify B*H*g == g in both Python and MATLAB."""
+        np.random.seed(504)
+        n, k, dscale = 20, 5, 1e-3
+        Q = np.eye(n) * 2.0
+        x0 = np.random.randn(n)
+        g_test = np.random.randn(n)
+
+        H, _ = self._build_lbfgs_state(n, k, dscale, Q, x0, 5)
+        hg_py = lbfgs_hprod(H, g_test)
+        bhg_py = lbfgs_bprod(H, hg_py)
+
+        script = """
+        n = double(n); k = double(k); dscale = double(dscale);
+        Q = eye(n) * 2.0;
+        x = x0;
+        H = lbfgsinit(n, k, dscale);
+        for i = 1:5
+            g1 = Q * x;
+            p = -g1;
+            step = 0.1;
+            x_new = x + step * p;
+            g2 = Q * x_new;
+            [H, noup] = lbfgsupdate(H, step, p, g1, g2);
+            x = x_new;
+        end
+        hg_matlab = lbfgshprod(H, g_test);
+        bhg_matlab = lbfgsbprod(H, hg_matlab);
+        """
+        out = _run_octave_script(script, {
+            'n': float(n), 'k': float(k), 'dscale': float(dscale),
+            'x0': x0, 'g_test': g_test
+        })
+        assert out is not None, "Octave script failed"
+
+        # Both Python and MATLAB should recover g_test
+        np.testing.assert_allclose(bhg_py, g_test, rtol=1e-10)
+        np.testing.assert_allclose(out['bhg_matlab'].flatten(), g_test.flatten(), rtol=1e-10)
+
+        # And they should match each other
+        np.testing.assert_allclose(bhg_py, out['bhg_matlab'].flatten(),
+                                   rtol=1e-12, atol=1e-14)
+
+
+# =========================================================================
+# Octave cross-validation: full hybrid solver
+# =========================================================================
+
+@pytest.mark.matlab
+@pytest.mark.skipif(not octave_available(), reason="Octave not available")
+class TestHybridModeVsOctave:
+    """Cross-validate full hybrid mode solver against MATLAB."""
+
+    def test_hybrid_bpdn_matches_matlab(self):
+        """Hybrid BPDN should produce similar results to MATLAB hybrid."""
+        np.random.seed(600)
+        m, n, k = 50, 100, 8
+        A = np.random.randn(m, n)
+        x_true = np.zeros(n)
+        x_true[:k] = np.random.randn(k)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        sigma = 0.1 * np.linalg.norm(b)
+
+        x_py, r_py, g_py, info_py = spg_bpdn(A, b, sigma, hybrid_mode=True, verbosity=0)
+
+        script = """
+        opts = spgSetParms('hybridMode', true, 'verbosity', 0);
+        [x_mat, r_mat, g_mat, info_mat] = spgl1(A, b, 0, sigma, [], opts);
+        rnorm_mat = info_mat.rNorm;
+        stat_mat = info_mat.stat;
+        clear opts info_mat x_mat r_mat g_mat A b sigma;
+        """
+        out = _run_octave_script(script, {
+            'A': A, 'b': b, 'sigma': float(sigma)
+        }, timeout=60)
+        assert out is not None, "Octave hybrid BPDN failed"
+
+        rnorm_mat = float(out['rnorm_mat'].flatten()[0])
+        stat_mat = int(out['stat_mat'].flatten()[0])
+
+        assert info_py['stat'] in [1, 2, 3, 4, 5]
+        assert stat_mat in [1, 2, 3, 4, 5]
+
+        np.testing.assert_allclose(info_py['rnorm'], rnorm_mat, rtol=0.2,
+                                   err_msg="Hybrid BPDN residual norms differ significantly")
+
+    def test_hybrid_lasso_matches_matlab(self):
+        """Hybrid LASSO should produce similar results to MATLAB hybrid."""
+        np.random.seed(601)
+        m, n, k = 50, 100, 8
+        A = np.random.randn(m, n)
+        x_true = np.zeros(n)
+        x_true[:k] = np.random.randn(k)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        tau = np.linalg.norm(x_true, 1) * 1.2
+
+        x_py, r_py, g_py, info_py = spgl1(A, b, tau=tau, hybrid_mode=True, verbosity=0)
+
+        script = """
+        opts = spgSetParms('hybridMode', true, 'verbosity', 0);
+        [x_mat, r_mat, g_mat, info_mat] = spgl1(A, b, tau, 0, [], opts);
+        rnorm_mat = info_mat.rNorm;
+        stat_mat = info_mat.stat;
+        clear opts info_mat x_mat r_mat g_mat A b tau;
+        """
+        out = _run_octave_script(script, {
+            'A': A, 'b': b, 'tau': float(tau)
+        }, timeout=60)
+        assert out is not None, "Octave hybrid LASSO failed"
+
+        rnorm_mat = float(out['rnorm_mat'].flatten()[0])
+        assert info_py['stat'] in [1, 2, 3, 4, 5]
+        # Both should be near-optimal; allow small absolute difference when both are tiny
+        np.testing.assert_allclose(info_py['rnorm'], rnorm_mat, rtol=0.5, atol=0.01,
+                                   err_msg="Hybrid LASSO residual norms differ")
+
+    def test_standard_vs_hybrid_both_match_matlab(self):
+        """Both standard and hybrid modes should match MATLAB counterparts."""
+        np.random.seed(602)
+        m, n, k = 60, 120, 5
+        A = np.random.randn(m, n)
+        x_true = np.zeros(n)
+        x_true[:k] = np.random.randn(k)
+        b = A @ x_true + 0.01 * np.random.randn(m)
+        sigma = 0.1 * np.linalg.norm(b)
+
+        x_std, _, _, info_std = spg_bpdn(A, b, sigma, verbosity=0)
+        x_hyb, _, _, info_hyb = spg_bpdn(A, b, sigma, hybrid_mode=True, verbosity=0)
+
+        script = """
+        opts_std = spgSetParms('verbosity', 0);
+        [x_std, r_std, g_std, info_std] = spgl1(A, b, 0, sigma, [], opts_std);
+        rnorm_std = info_std.rNorm;
+
+        opts_hyb = spgSetParms('hybridMode', true, 'verbosity', 0);
+        [x_hyb, r_hyb, g_hyb, info_hyb] = spgl1(A, b, 0, sigma, [], opts_hyb);
+        rnorm_hyb = info_hyb.rNorm;
+        clear opts_std opts_hyb info_std info_hyb x_std r_std g_std x_hyb r_hyb g_hyb A b sigma;
+        """
+        out = _run_octave_script(script, {
+            'A': A, 'b': b, 'sigma': float(sigma)
+        }, timeout=120)
+        assert out is not None, "Octave script failed"
+
+        np.testing.assert_allclose(info_std['rnorm'],
+                                   float(out['rnorm_std'].flatten()[0]),
+                                   rtol=0.15,
+                                   err_msg="Standard mode rnorm mismatch")
+        np.testing.assert_allclose(info_hyb['rnorm'],
+                                   float(out['rnorm_hyb'].flatten()[0]),
+                                   rtol=0.2,
+                                   err_msg="Hybrid mode rnorm mismatch")
 
 
 if __name__ == "__main__":

--- a/pytests/test_lbfgs.py
+++ b/pytests/test_lbfgs.py
@@ -2,10 +2,11 @@
 Test L-BFGS infrastructure.
 
 Tests the L-BFGS quasi-Newton approximation used by hybrid mode.
+Matches the MATLAB SPGL1 lbfgs* functions.
 """
 import numpy as np
 import pytest
-from spgl1.lbfgs import lbfgs_init, lbfgs_update, lbfgs_hprod, lbfgs_reset
+from spgl1.lbfgs import lbfgs_init, lbfgs_update, lbfgs_hprod, lbfgs_bprod
 
 
 class TestLBFGSBasics:
@@ -15,316 +16,237 @@ class TestLBFGSBasics:
         """Test L-BFGS initialization."""
         n = 100
         k = 8
-        state = lbfgs_init(n, k)
+        H = lbfgs_init(n, k, dscale=1.0)
 
-        assert state.n == n
-        assert state.k == k
-        assert state.S.shape == (n, k)
-        assert state.Y.shape == (n, k)
-        assert state.rho.shape == (k,)
-        assert state.filled == 0
-        assert state.head == 0
-        assert state.gamma == 1.0
+        assert H.jMax == k
+        assert H.S.shape == (n, k)
+        assert H.Y.shape == (n, k)
+        assert H.r.shape == (k,)
+        assert H.rank == 0
+        assert H.jNew == 0
+        assert H.jOld == 0
+        assert H.gamma == 1.0
 
-    def test_init_custom_gamma(self):
-        """Test initialization with custom gamma."""
-        state = lbfgs_init(50, k=5, gamma=2.5)
-        assert state.gamma == 2.5
+    def test_init_custom_dscale(self):
+        """Test initialization with custom dscale."""
+        H = lbfgs_init(50, k=5, dscale=2.5)
+        assert H.gamma == 2.5
+        assert H.delta == pytest.approx(1.0 / 2.5)
 
-    def test_update_single(self):
-        """Test single L-BFGS update."""
-        n = 50
-        state = lbfgs_init(n, k=5)
-
-        # Create valid curvature pair
-        s = np.random.randn(n)
-        y = np.random.randn(n)
-        y += 0.1 * s  # Ensure y'*s > 0
-
-        success = lbfgs_update(state, s, y, force=True)
-
-        assert success
-        assert state.filled == 1
-        assert state.head == 1
-        assert np.allclose(state.S[:, 0], s)
-        # Note: Y may be corrected if curvature is bad, so just check it's stored
-        assert np.linalg.norm(state.Y[:, 0]) > 0
-        assert state.rho[0] > 0
-
-    def test_update_multiple(self):
-        """Test multiple L-BFGS updates (circular buffer)."""
+    def test_update_and_hprod(self):
+        """Test update followed by H*g."""
+        np.random.seed(100)
         n = 30
         k = 5
-        state = lbfgs_init(n, k)
+        H = lbfgs_init(n, k, dscale=1e-3)
 
-        # Add 10 updates (more than k)
-        for i in range(10):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.5 * s  # Ensure positive curvature
-            success = lbfgs_update(state, s, y, force=True)
-            assert success
+        # Create a simple quadratic: f(x) = 0.5*x'Qx, g = Qx
+        Q = np.eye(n) + 0.1 * np.random.randn(n, n)
+        Q = Q.T @ Q  # SPD
 
-        # Should have exactly k stored
-        assert state.filled == k
-        assert state.head == 0  # Wrapped around: 10 % 5 = 0
+        x = np.random.randn(n)
+        g1 = Q @ x
+        p = -g1  # Steepest descent
+        step = 0.1
+        x_new = x + step * p
+        g2 = Q @ x_new
 
-    def test_update_bad_curvature_no_force(self):
-        """Test update with negative curvature (force=False)."""
-        n = 30
-        state = lbfgs_init(n, k=5)
+        noup = lbfgs_update(H, step, p, g1, g2)
+        assert H.rank >= 0
 
-        s = np.random.randn(n)
-        y = -s  # y'*s = -||s||^2 < 0 (bad curvature)
-
-        success = lbfgs_update(state, s, y, force=False)
-
-        # Should fail and not add to buffer
-        assert not success
-        assert state.filled == 0
-
-    def test_update_bad_curvature_with_force(self):
-        """Test update with negative curvature (force=True applies correction)."""
-        n = 30
-        state = lbfgs_init(n, k=5)
-
-        s = np.random.randn(n)
-        y = -s  # Bad curvature
-
-        success = lbfgs_update(state, s, y, force=True)
-
-        # Should succeed after correction
-        assert success
-        assert state.filled == 1
+        d = lbfgs_hprod(H, g2)
+        assert d.shape == (n,)
+        assert np.all(np.isfinite(d))
 
     def test_hprod_no_history(self):
-        """Test H*g with no history (should return scaled identity)."""
+        """H*g with no history returns gamma * g."""
         n = 40
-        state = lbfgs_init(n, k=5, gamma=2.0)
+        H = lbfgs_init(n, k=5, dscale=2.0)
         g = np.random.randn(n)
-
-        d = lbfgs_hprod(state, g, mode=1)
-
-        # Should be gamma * g
+        d = lbfgs_hprod(H, g)
         assert np.allclose(d, 2.0 * g)
 
-    def test_hprod_with_history(self):
-        """Test H*g with some history."""
-        n = 50
-        state = lbfgs_init(n, k=5)
-
-        # Add a few updates
-        for i in range(3):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.2 * s
-            lbfgs_update(state, s, y, force=True)
-
-        g = np.random.randn(n)
-        d = lbfgs_hprod(state, g, mode=1)
-
-        # Should produce valid result
-        assert d.shape == g.shape
-        assert np.all(np.isfinite(d))
-        # Direction should generally be non-trivial
-        assert np.linalg.norm(d) > 0
-
-    def test_hprod_mode2(self):
-        """Test H^{-1}*g (mode=2)."""
+    def test_bprod_no_history(self):
+        """B*g with no history returns delta * g."""
         n = 40
-        state = lbfgs_init(n, k=5)
-
-        # Add updates
-        for i in range(3):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.3 * s
-            lbfgs_update(state, s, y, force=True)
-
+        H = lbfgs_init(n, k=5, dscale=2.0)
         g = np.random.randn(n)
-        d_mode1 = lbfgs_hprod(state, g, mode=1)  # H*g
-        d_mode2 = lbfgs_hprod(state, g, mode=2)  # H^{-1}*g
+        p = lbfgs_bprod(H, g)
+        assert np.allclose(p, 0.5 * g)
 
-        # mode2 should give different result than mode1
-        assert not np.allclose(d_mode1, d_mode2)
-        assert np.all(np.isfinite(d_mode2))
+    def test_multiple_updates(self):
+        """Test multiple updates with circular buffer."""
+        np.random.seed(102)
+        n = 30
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
+
+        Q = np.eye(n) * 2.0
+        x = np.random.randn(n)
+
+        for i in range(10):
+            g1 = Q @ x
+            p = -g1
+            step = 0.1
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
+
+        g = Q @ x
+        d = lbfgs_hprod(H, g)
+        assert np.all(np.isfinite(d))
+        assert H.rank <= k
 
     def test_linearity(self):
         """Test linearity of H*g."""
+        np.random.seed(103)
         n = 50
-        state = lbfgs_init(n, k=5)
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
 
-        # Build some history
+        Q = np.eye(n) + 0.3 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
+
         for i in range(4):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.2 * s
-            lbfgs_update(state, s, y, force=True)
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
 
         g1 = np.random.randn(n)
         g2 = np.random.randn(n)
-        alpha = 2.3
-        beta = 1.7
+        alpha, beta = 2.3, 1.7
 
-        # H*(alpha*g1 + beta*g2)
-        d_combined = lbfgs_hprod(state, alpha * g1 + beta * g2, mode=1)
-
-        # alpha*H*g1 + beta*H*g2
-        d1 = lbfgs_hprod(state, g1, mode=1)
-        d2 = lbfgs_hprod(state, g2, mode=1)
+        d_combined = lbfgs_hprod(H, alpha * g1 + beta * g2)
+        d1 = lbfgs_hprod(H, g1)
+        d2 = lbfgs_hprod(H, g2)
         d_separate = alpha * d1 + beta * d2
 
-        # Should be equal (linear operator)
-        assert np.allclose(d_combined, d_separate, rtol=1e-14)
-
-    def test_reset(self):
-        """Test L-BFGS reset."""
-        n = 40
-        state = lbfgs_init(n, k=5)
-
-        # Add some updates
-        for i in range(3):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.5 * s  # Ensure positive curvature
-            lbfgs_update(state, s, y, force=True)
-
-        assert state.filled == 3
-
-        # Reset
-        lbfgs_reset(state)
-
-        assert state.filled == 0
-        assert state.head == 0
-        assert np.allclose(state.S, 0.0)
-        assert np.allclose(state.Y, 0.0)
-
-    def test_reset_with_gamma(self):
-        """Test reset with new gamma."""
-        state = lbfgs_init(30, k=5, gamma=1.0)
-        lbfgs_reset(state, gamma=3.0)
-
-        assert state.gamma == 3.0
-        assert state.filled == 0
-
-    def test_full_history(self):
-        """Test behavior when history is full."""
-        n = 30
-        k = 5
-        state = lbfgs_init(n, k)
-
-        # Fill history exactly
-        for i in range(k):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.2 * s
-            lbfgs_update(state, s, y, force=True)
-
-        assert state.filled == k
-        assert state.head == 0  # Wrapped around
-
-        # Add one more (should overwrite oldest)
-        s = np.random.randn(n)
-        y = np.random.randn(n) + 0.2 * s
-        lbfgs_update(state, s, y, force=True)
-
-        assert state.filled == k  # Still k
-        assert state.head == 1  # Advanced by 1
-
-    def test_positive_definiteness(self):
-        """Test that L-BFGS maintains positive definiteness."""
-        n = 50
-        state = lbfgs_init(n, k=5)
-
-        # Add valid curvature pairs
-        for i in range(5):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.5 * s  # Ensure y'*s > 0
-            lbfgs_update(state, s, y, force=True)
-
-        # H should be positive definite: g'*H*g > 0 for all g != 0
-        for trial in range(10):
-            g = np.random.randn(n)
-            d = lbfgs_hprod(state, g, mode=1)
-
-            # Check g'*d > 0 (positive definiteness)
-            inner_product = np.dot(g, d)
-            assert inner_product > 0, f"Lost positive definiteness: g'*H*g = {inner_product}"
-
-    def test_descent_direction(self):
-        """Test that H*(-g) gives descent direction."""
-        n = 50
-        state = lbfgs_init(n, k=5)
-
-        # Add some history
-        for i in range(4):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.3 * s
-            lbfgs_update(state, s, y, force=True)
-
-        # For minimization, we want d = -H*g
-        g = np.random.randn(n)
-        d = -lbfgs_hprod(state, g, mode=1)
-
-        # d should be a descent direction: g'*d < 0
-        assert np.dot(g, d) < 0
+        assert np.allclose(d_combined, d_separate, rtol=1e-12)
 
 
 class TestLBFGSNumericalProperties:
     """Test numerical properties of L-BFGS."""
 
-    def test_gamma_update(self):
-        """Test that gamma is updated correctly."""
-        n = 30
-        state = lbfgs_init(n, k=5, gamma=1.0)
+    def test_positive_definiteness(self):
+        """H should be positive definite: g'*H*g > 0."""
+        np.random.seed(200)
+        n = 50
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
 
-        s = np.random.randn(n)
-        y = np.random.randn(n) + 0.5 * s
+        Q = np.eye(n) + 0.5 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
 
-        # Compute expected gamma
-        ys = np.dot(y, s)
-        yy = np.dot(y, y)
-        expected_gamma = ys / yy
+        for i in range(5):
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
 
-        lbfgs_update(state, s, y, force=True)
+        for trial in range(10):
+            g = np.random.randn(n)
+            d = lbfgs_hprod(H, g)
+            assert g @ d > 0, f"Lost positive definiteness: g'*H*g = {g @ d}"
 
-        assert np.abs(state.gamma - expected_gamma) < 1e-14
+    def test_descent_direction(self):
+        """H*(-g) should give descent direction."""
+        np.random.seed(201)
+        n = 50
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
 
-    def test_rho_values(self):
-        """Test that rho values are computed correctly."""
-        n = 30
-        state = lbfgs_init(n, k=5)
+        Q = np.eye(n) + 0.3 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
 
-        s = np.random.randn(n)
-        y = np.random.randn(n) + 0.5 * s  # Ensure good curvature
+        for i in range(4):
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
 
-        ys = np.dot(y, s)
-        expected_rho = 1.0 / ys
-
-        # Don't use force=True here so y isn't modified
-        success = lbfgs_update(state, s, y, force=False)
-        assert success
-
-        # rho should match expected (within tolerance for numerical errors)
-        assert np.abs(state.rho[0] - expected_rho) < 1e-12
+        g = Q @ x
+        d = -lbfgs_hprod(H, g)
+        assert g @ d < 0
 
     def test_symmetry(self):
-        """Test that H is symmetric: (H*g1)'*g2 = g1'*(H*g2)."""
+        """H should be symmetric: (H*g1)'*g2 = g1'*(H*g2)."""
+        np.random.seed(202)
         n = 40
-        state = lbfgs_init(n, k=5)
+        k = 5
+        H = lbfgs_init(n, k, dscale=1e-3)
 
-        # Build history
+        Q = np.eye(n) + 0.2 * np.random.randn(n, n)
+        Q = Q.T @ Q
+        x = np.random.randn(n)
+
         for i in range(3):
-            s = np.random.randn(n)
-            y = np.random.randn(n) + 0.2 * s
-            lbfgs_update(state, s, y, force=True)
+            g1 = Q @ x
+            p = -g1
+            step = 0.05
+            x_new = x + step * p
+            g2 = Q @ x_new
+            lbfgs_update(H, step, p, g1, g2)
+            x = x_new
 
         g1 = np.random.randn(n)
         g2 = np.random.randn(n)
 
-        d1 = lbfgs_hprod(state, g1, mode=1)  # H*g1
-        d2 = lbfgs_hprod(state, g2, mode=1)  # H*g2
+        d1 = lbfgs_hprod(H, g1)
+        d2 = lbfgs_hprod(H, g2)
 
-        # Check symmetry (relative tolerance)
-        sym1 = np.dot(d1, g2)
-        sym2 = np.dot(g1, d2)
+        sym1 = d1 @ g2
+        sym2 = g1 @ d2
+        rel_error = abs(sym1 - sym2) / (abs(sym1) + 1e-10)
+        assert rel_error < 1e-10, f"Symmetry violation: rel_error={rel_error}"
 
-        rel_error = np.abs(sym1 - sym2) / (np.abs(sym1) + 1e-10)
-        assert rel_error < 1e-10, f"Symmetry violation: {sym1} != {sym2}, rel_error={rel_error}"
+    def test_curvature_skip(self):
+        """Test that updates with bad curvature are handled."""
+        n = 20
+        H = lbfgs_init(n, k=3, dscale=1.0)
+
+        # p = e1, g1 = -e1 → gtp1 = -1
+        # g2 = -e1 → gtp2 = -1
+        # noup = gtp2 <= 0.91*gtp1 → -1 <= -0.91 → True
+        p = np.zeros(n)
+        p[0] = 1.0
+        g1 = -p.copy()
+        g2 = g1.copy()
+        noup = lbfgs_update(H, 1.0, p, g1, g2)
+        assert noup
+        assert H.status == 2
+
+    def test_damped_update(self):
+        """Test damped BFGS update when yts < 0.2 * sbs."""
+        np.random.seed(203)
+        n = 20
+        H = lbfgs_init(n, k=5, dscale=1.0)
+
+        # First do a valid update to build some history
+        Q = np.eye(n) * 2.0
+        x = np.random.randn(n)
+        g1 = Q @ x
+        p = -g1
+        step = 0.1
+        x_new = x + step * p
+        g2 = Q @ x_new
+        noup = lbfgs_update(H, step, p, g1, g2)
+        assert not noup
+        # Status 0 or 1 depending on damping
+        assert H.status in [0, 1]
 
 
 if __name__ == "__main__":

--- a/spgl1/lbfgs.py
+++ b/spgl1/lbfgs.py
@@ -4,336 +4,315 @@ L-BFGS quasi-Newton approximation for hybrid mode.
 This module implements Limited-memory BFGS (Broyden-Fletcher-Goldfarb-Shanno)
 for approximating the inverse Hessian in SPGL1's hybrid mode.
 
-L-BFGS maintains a limited history of curvature pairs (s, y) where:
-- s = x_new - x_old (step in primal space)
-- y = g_new - g_old (step in gradient space)
-
-These are used to approximate H ≈ inverse Hessian without storing the full matrix.
+Faithfully ports the MATLAB SPGL1 implementation:
+- lbfgsinit.m
+- lbfgsupdate.m (with damped BFGS and compact representation)
+- lbfgshprod.m (two-loop recursion)
+- lbfgsbprod.m (B-product via compact representation)
 """
 import numpy as np
-from dataclasses import dataclass
-from typing import Optional
+from scipy.linalg import lu_factor, lu_solve
 
 
-@dataclass
 class LBFGSState:
-    """L-BFGS state for maintaining Hessian approximation.
+    """L-BFGS state matching MATLAB struct.
 
     Attributes
     ----------
-    n : int
-        Problem dimension (support set size)
-    k : int
-        Maximum history size
-    S : ndarray
-        Step vectors (n x k) - circular buffer
-    Y : ndarray
-        Gradient difference vectors (n x k) - circular buffer
-    rho : ndarray
-        Curvature values 1/(y'*s) for each pair (k,)
+    jNew : int
+        Index of newest vectors (1-based in MATLAB, 0-based here).
+    jOld : int
+        Index of oldest vectors (0-based).
+    jMax : int
+        Maximum history size.
+    S : ndarray (n, jMax)
+        Step vectors.
+    Y : ndarray (n, jMax)
+        Gradient difference vectors.
     gamma : float
-        Scaling factor for initial Hessian (H0 = gamma * I)
-    head : int
-        Current position in circular buffer (0 to k-1)
-    filled : int
-        Number of filled positions (0 to k)
+        Scaling for initial Hessian H0 = gamma * I.
+    r : ndarray (jMax,)
+        1/(s'*y) for each slot, 0 if invalid.
+    delta : float
+        1/gamma, scaling for B0 = delta * I.
+    valid : ndarray (jMax,) bool
+        Which slots have valid data.
+    rank : int
+        Number of valid slots.
+    STS : ndarray (jMax, jMax)
+        S'*S matrix.
+    L : ndarray (jMax, jMax)
+        Lower triangular part of S'*Y.
+    D : ndarray (jMax, jMax)
+        Diagonal of S'*Y.
+    M : ndarray (2*jMax, 2*jMax)
+        Compact representation matrix.
+    ML : ndarray or None
+        LU factor L.
+    MU : ndarray or None
+        LU factor U.
+    status : int
+        0=updated, 1=corrected, 2=no update.
     """
-    n: int
-    k: int
-    S: np.ndarray
-    Y: np.ndarray
-    rho: np.ndarray
-    gamma: float
-    head: int
-    filled: int
+
+    def __init__(self, n, k, dscale=1.0):
+        self.jNew = 0
+        self.jOld = 0
+        self.jMax = k
+        self.S = np.zeros((n, k))
+        self.Y = np.zeros((n, k))
+
+        # Data specific to H
+        self.gamma = dscale
+        self.r = np.zeros(k)
+
+        # Data specific to B
+        self.delta = 1.0 / dscale if dscale != 0 else 1.0
+        self.valid = np.zeros(k, dtype=bool)
+        self.rank = 0
+        self.STS = np.zeros((k, k))
+        self.L = np.zeros((k, k))
+        self.D = np.zeros((k, k))
+        self.M = np.zeros((2 * k, 2 * k))
+        self.ML = None
+        self.MU = None
+
+        # Status
+        self.status = 0
 
 
-def lbfgs_init(n, k=8, gamma=1.0):
+def lbfgs_init(n, k=8, dscale=1.0):
     """Initialize L-BFGS data structure.
 
     Parameters
     ----------
     n : int
-        Problem dimension (support set size)
+        Problem dimension.
     k : int, optional
-        Maximum history size (default: 8)
-        Typical values: 3-20. Larger k uses more memory but may converge faster.
-    gamma : float, optional
-        Initial Hessian scaling H0 = gamma * I (default: 1.0)
+        Maximum history size (default: 8).
+    dscale : float, optional
+        Initial Hessian scaling H0 = dscale * I (default: 1.0).
 
     Returns
     -------
-    state : LBFGSState
-        Initialized L-BFGS state
+    H : LBFGSState
+        Initialized L-BFGS state.
 
     Notes
     -----
     Equivalent to MATLAB's lbfgsinit.m
-
-    The L-BFGS approximation uses the most recent k curvature pairs to
-    approximate the inverse Hessian. Memory usage is O(nk).
-
-    Examples
-    --------
-    >>> state = lbfgs_init(100, k=5)
-    >>> state.n
-    100
-    >>> state.k
-    5
     """
-    return LBFGSState(
-        n=n,
-        k=k,
-        S=np.zeros((n, k)),
-        Y=np.zeros((n, k)),
-        rho=np.zeros(k),
-        gamma=gamma,
-        head=0,
-        filled=0
-    )
+    return LBFGSState(n, k, dscale)
 
 
-def lbfgs_update(state, s, y, force=False):
-    """Update L-BFGS approximation with new curvature pair.
+def lbfgs_bprod(H, g):
+    """Compute B*g where B is the L-BFGS Hessian approximation.
+
+    Uses the compact representation [(9.15), p.231] from Nocedal & Wright.
 
     Parameters
     ----------
-    state : LBFGSState
-        Current L-BFGS state (modified in-place)
-    s : ndarray
-        Step vector (x_new - x_old), shape (n,)
-    y : ndarray
-        Gradient difference (g_new - g_old), shape (n,)
-    force : bool, optional
-        Force update even if curvature condition fails (default: False)
-        When True, applies curvature correction to ensure positive definiteness.
+    H : LBFGSState
+        Current L-BFGS state.
+    g : ndarray (n,)
+        Input vector.
 
     Returns
     -------
-    success : bool
-        True if update succeeded, False if curvature condition failed and force=False
+    p : ndarray (n,)
+        B*g result.
+
+    Notes
+    -----
+    Equivalent to MATLAB's lbfgsbprod.m
+    """
+    if H.ML is None:
+        return H.delta * g
+
+    jMax = H.jMax
+    valid = H.valid
+    rank = H.rank
+
+    # Compute v1 = delta * S'*g, v2 = Y'*g
+    v1 = H.delta * (H.S.T @ g)
+    v2 = H.Y.T @ g
+
+    # Select valid entries
+    p_compact = np.concatenate([v1[valid], v2[valid]])
+
+    # Solve M * result = p_compact using LU factors
+    result = lu_solve(H._lu_factors, p_compact)
+
+    # Reconstruct: p = delta*S*result[0:rank] + Y*result[rank:]
+    pe1 = np.zeros(jMax)
+    pe1[valid] = result[:rank]
+    v1_out = H.S @ (pe1 * H.delta)
+
+    pe2 = np.zeros(jMax)
+    pe2[valid] = result[rank:]
+    v2_out = H.Y @ pe2
+
+    p = v1_out + v2_out
+
+    return H.delta * g - p
+
+
+def lbfgs_update(H, step, p, g1, g2):
+    """Update L-BFGS approximation with damped BFGS.
+
+    Parameters
+    ----------
+    H : LBFGSState
+        Current state (modified in-place).
+    step : float
+        Step length.
+    p : ndarray (n,)
+        Search direction.
+    g1 : ndarray (n,)
+        Gradient before step.
+    g2 : ndarray (n,)
+        Gradient after step.
+
+    Returns
+    -------
+    noup : bool
+        True if update was skipped (curvature condition failed).
 
     Notes
     -----
     Equivalent to MATLAB's lbfgsupdate.m
 
-    The curvature condition y'*s > 0 must hold for positive definiteness.
-    If it fails and force=False, the update is skipped.
-
-    Implements curvature correction (Powell damping): if y'*s is too small,
-    we modify y to ensure numerical stability:
-        y_corrected = y + (threshold - y'*s) / s'*s * s
-
-    The scaling factor gamma is updated based on the most recent curvature:
-        gamma = (y'*s) / (y'*y)
-
-    This is the recommended scaling from Nocedal & Wright (2006).
-
-    Examples
-    --------
-    >>> state = lbfgs_init(10, k=5)
-    >>> s = np.random.randn(10)
-    >>> y = np.random.randn(10) + 0.1 * s  # Ensure y'*s > 0
-    >>> success = lbfgs_update(state, s, y)
-    >>> success
-    True
-    >>> state.filled
-    1
+    Uses damped BFGS update from Nocedal & Wright, 2nd Edition, p.537.
+    The curvature condition requires g2'*p <= 0.91 * g1'*p (note: these
+    are typically negative since p is a descent direction).
     """
-    # Check curvature condition: y'*s > 0
-    ys = np.dot(y, s)
-    ss = np.dot(s, s)
+    jMax = H.jMax
+    jOld = H.jOld
 
-    # Curvature correction threshold (1e-8 * ||s||^2)
-    # This ensures we maintain positive definiteness
-    threshold = 1e-8 * ss
+    gtp1 = g1 @ p
+    gtp2 = g2 @ p
+    noup = gtp2 <= 0.91 * gtp1  # Curvature requirement
 
-    if ys < threshold:
-        if not force:
-            # Skip update - curvature condition violated
-            return False
-        else:
-            # Apply Powell damping: correct y to satisfy curvature condition
-            # y_corrected = y + (threshold - ys) / ss * s
-            correction = (threshold - ys) / ss
-            y = y + correction * s
-            ys = threshold  # Update curvature value
+    if not noup:
+        H.status = 0  # Update
 
-    # Compute rho = 1 / (y'*s)
-    rho = 1.0 / ys
+        # Nocedal & Wright, 2nd Edition, p.537
+        s = step * p
+        y = g2 - g1
+        bs = lbfgs_bprod(H, s)
+        sbs = s @ bs
+        yts = step * (gtp2 - gtp1)
 
-    # Add to circular buffer at current head position
-    idx = state.head
-    state.S[:, idx] = s
-    state.Y[:, idx] = y
-    state.rho[idx] = rho
+        if yts < 0.2 * sbs:
+            theta = (0.8 * sbs) / (sbs - yts)
+            y = theta * y + (1 - theta) * bs
+            yts = theta * yts + (1 - theta) * sbs
+            H.status = 1  # Correction
 
-    # Advance head and update filled count
-    state.head = (state.head + 1) % state.k
-    state.filled = min(state.filled + 1, state.k)
+    if noup:
+        # Shift: mark oldest as invalid but advance pointers
+        H.valid[jOld] = False
+        H.r[jOld] = 0.0
+        H.status = 2  # No update
+    else:
+        yty = y @ y
 
-    # Update gamma scaling using most recent curvature
-    # gamma = (y'*s) / (y'*y) - recommended by Nocedal & Wright
-    yy = np.dot(y, y)
-    if yy > 1e-20:  # Avoid division by zero
-        state.gamma = ys / yy
+        # Replace oldest vectors
+        H.S[:, jOld] = s
+        H.Y[:, jOld] = y
 
-    return True
+        # Update initial matrix H0 = gamma * I
+        H.gamma = yts / yty  # s'y / y'y
+        H.r[jOld] = 1.0 / yts
+
+        # Update data for B
+        sTS = step * (p @ H.S)
+        H.delta = yty / yts  # y'y / s'y
+        H.valid[jOld] = True
+        H.STS[jOld, :] = sTS
+        H.STS[:, jOld] = sTS
+        H.L[jOld, :] = s @ H.Y
+        H.L[:, jOld] = 0.0
+        H.D[jOld, jOld] = yts
+
+    # Update and factorize matrix M for B
+    H.rank = int(np.sum(H.valid))
+    H.M = np.block([
+        [H.delta * H.STS, H.L],
+        [H.L.T, -H.D]
+    ])
+    valid_idx = np.concatenate([
+        np.where(H.valid)[0],
+        np.where(H.valid)[0] + jMax
+    ])
+    if H.rank > 0:
+        M_sub = H.M[np.ix_(valid_idx, valid_idx)]
+        H._lu_factors = lu_factor(M_sub)
+        H.ML = True  # Signal that LU factors exist
+        H.MU = True
+    else:
+        H.ML = None
+        H.MU = None
+        H._lu_factors = None
+
+    # Advance pointers
+    H.jNew = jOld
+    if jOld == 0:
+        H.jOld = jMax - 1
+    else:
+        H.jOld = jOld - 1
+
+    return noup
 
 
-def lbfgs_hprod(state, g, mode=1):
-    """Compute H*g or solve H*d = g where H is L-BFGS Hessian approximation.
-
-    This is the core L-BFGS operation, using the two-loop recursion algorithm
-    to efficiently compute matrix-vector products without forming H explicitly.
+def lbfgs_hprod(H, g):
+    """Compute H*g (inverse Hessian product) using two-loop recursion.
 
     Parameters
     ----------
-    state : LBFGSState
-        Current L-BFGS state
-    g : ndarray
-        Input vector (gradient or direction), shape (n,)
-    mode : int, optional
-        1: Compute d = H*g (approximate inverse Hessian, default)
-        2: Solve H*d = g (approximate Hessian)
+    H : LBFGSState
+        Current L-BFGS state.
+    g : ndarray (n,)
+        Input vector (typically gradient).
 
     Returns
     -------
-    d : ndarray
-        Result vector, shape (n,)
-        - mode=1: d = H*g (quasi-Newton direction)
-        - mode=2: d = B*g where B = H^{-1} (Hessian approximation)
+    p : ndarray (n,)
+        H*g result (quasi-Newton direction).
 
     Notes
     -----
     Equivalent to MATLAB's lbfgshprod.m
 
-    Uses the two-loop recursion algorithm (Nocedal & Wright, Algorithm 7.4):
-
-    **Algorithm (mode=1, compute H*g)**:
-    1. Right loop (backward through history from newest to oldest):
-       - Compute alpha_i = rho_i * s_i' * q
-       - Update q = q - alpha_i * y_i
-
-    2. Scale by initial Hessian approximation:
-       - r = gamma * q
-
-    3. Left loop (forward through history from oldest to newest):
-       - Compute beta = rho_i * y_i' * r
-       - Update r = r + s_i * (alpha_i - beta)
-
-    **For mode=2** (compute B*g = H^{-1}*g):
-    - Swap roles of S and Y in the algorithm
-    - Use gamma_inv = 1/gamma as scaling
-
-    **Complexity**: O(nk) where n is dimension, k is history size
-
-    Examples
-    --------
-    >>> state = lbfgs_init(10, k=3)
-    >>> for i in range(3):
-    ...     s = np.random.randn(10)
-    ...     y = np.random.randn(10) + 0.2 * s
-    ...     lbfgs_update(state, s, y)
-    >>> g = np.random.randn(10)
-    >>> d = lbfgs_hprod(state, g, mode=1)
-    >>> d.shape
-    (10,)
+    Uses Algorithm 9.2 (p.226) from Nocedal & Wright, 1999.
+    Iterates over ALL jMax slots; slots with r[k]==0 are skipped
+    automatically since alpha[k] and beta will be zero.
     """
-    if state.filled == 0:
-        # No history - return scaled identity: H*g = gamma * g
-        return state.gamma * g
+    jMax = H.jMax
+    jNew = H.jNew
+    alfa = np.zeros(jMax)
 
-    n = state.n
-    m = state.filled  # Number of stored curvature pairs
+    p = g.copy()
 
-    # Determine which vectors to use based on mode
-    if mode == 1:
-        # mode=1: H*g (approximate inverse Hessian)
-        # Use standard L-BFGS with S, Y
-        S = state.S
-        Y = state.Y
-        gamma = state.gamma
-    else:
-        # mode=2: B*g = H^{-1}*g (approximate Hessian)
-        # Swap S and Y (duality)
-        S = state.Y
-        Y = state.S
-        gamma = 1.0 / state.gamma if state.gamma > 1e-20 else 1.0
+    # Right loop: from "newest" to "oldest"
+    for i in range(jMax):
+        k = (jNew + i) % jMax
+        s = H.S[:, k]
+        y = H.Y[:, k]
+        rho = H.r[k]
+        alfa[k] = rho * (s @ p)
+        p = p - alfa[k] * y
 
-    # Allocate alpha array for storing intermediate values
-    alpha = np.zeros(m)
+    # Scale by initial Hessian H0 = gamma * I
+    p = H.gamma * p
 
-    # Make copy of g for the recursion (we'll modify it)
-    q = g.copy()
+    # Left loop: from "oldest" to "newest"
+    for i in range(jMax - 1, -1, -1):
+        k = (jNew + i) % jMax
+        s = H.S[:, k]
+        y = H.Y[:, k]
+        rho = H.r[k]
+        beta = rho * (y @ p)
+        p = p + (alfa[k] - beta) * s
 
-    # ========================================
-    # Right loop: Backward through history
-    # ========================================
-    # Process from newest to oldest: head-1, head-2, ..., head-m
-    for i in range(m):
-        # Get index in circular buffer (newest first)
-        # If head=0, filled=3: indices are k-1, k-2, k-3 (wrapping)
-        idx = (state.head - 1 - i) % state.k
-
-        # Compute alpha_i = rho_i * s_i' * q
-        alpha[i] = state.rho[idx] * np.dot(S[:, idx], q)
-
-        # Update q = q - alpha_i * y_i
-        q -= alpha[i] * Y[:, idx]
-
-    # ========================================
-    # Scale by initial Hessian approximation
-    # ========================================
-    # r = H0 * q = gamma * q
-    r = gamma * q
-
-    # ========================================
-    # Left loop: Forward through history
-    # ========================================
-    # Process from oldest to newest: head-m, head-(m-1), ..., head-1
-    for i in range(m - 1, -1, -1):
-        # Get index in circular buffer (oldest first)
-        idx = (state.head - 1 - i) % state.k
-
-        # Compute beta = rho_i * y_i' * r
-        beta = state.rho[idx] * np.dot(Y[:, idx], r)
-
-        # Update r = r + s_i * (alpha_i - beta)
-        r += S[:, idx] * (alpha[i] - beta)
-
-    return r
-
-
-def lbfgs_reset(state, gamma=None):
-    """Reset L-BFGS state, clearing all history.
-
-    Parameters
-    ----------
-    state : LBFGSState
-        L-BFGS state to reset (modified in-place)
-    gamma : float, optional
-        New initial Hessian scaling (default: keep current gamma)
-
-    Notes
-    -----
-    This is useful when:
-    - Support set changes significantly
-    - Convergence stalls and you want a fresh start
-    - Problem structure changes
-
-    Examples
-    --------
-    >>> state = lbfgs_init(10, k=5)
-    >>> # ... do some updates ...
-    >>> lbfgs_reset(state)
-    >>> state.filled
-    0
-    """
-    state.filled = 0
-    state.head = 0
-    state.S.fill(0.0)
-    state.Y.fill(0.0)
-    state.rho.fill(0.0)
-    if gamma is not None:
-        state.gamma = gamma
+    return p

--- a/spgl1/spgl1.py
+++ b/spgl1/spgl1.py
@@ -865,6 +865,8 @@ def spgl1(
     relgap_min_f=1.0,
     relgap_min_r=1.0,
     max_runtime=np.inf,
+    hybrid_mode=False,
+    lbfgs_hist=8,
 ):
     r"""SPGL1 solver.
 
@@ -966,6 +968,12 @@ def spgl1(
         Maximum runtime in seconds. The solver will exit with EXIT_RUNTIME
         if this limit is exceeded. Default is np.inf (no limit).
         The runtime is checked adaptively to minimize overhead.
+    hybrid_mode : bool, optional
+        Enable L-BFGS hybrid mode for faster convergence (default: False).
+        When enabled, uses quasi-Newton search directions on identified
+        support set. Only applies to real-valued L1 problems.
+    lbfgs_hist : int, optional
+        L-BFGS history size (default: 8). Only used if hybrid_mode=True.
 
     Returns
     -------
@@ -1070,6 +1078,11 @@ def spgl1(
     test_updatetau = False  # Previous step did not update tau
     runtime_check_every = 1  # Check runtime every # iterations
 
+    # Hybrid mode imports and validation
+    if hybrid_mode:
+        from spgl1.lbfgs import lbfgs_init, lbfgs_update, lbfgs_hprod
+        from spgl1.productB import product_b, compute_sqrt_vectors
+
     # Determine initial x and see if problem is complex
     realx = np.isreal(A).all() and np.isreal(b).all()
     if x0 is None:
@@ -1080,6 +1093,14 @@ def spgl1(
     # Override realx when iscomplex flag is set
     if iscomplex:
         realx = False
+
+    # Validate hybrid mode: only applies to real-valued L1 problems
+    l1_mode = (project is _norm_l1_project)
+    if hybrid_mode:
+        if not (realx and l1_mode):
+            raise ValueError(
+                "Hybrid mode only applies to non-complex basis pursuit (L1) problems"
+            )
 
     # Check if all weights (if any) are strictly positive. In previous
     # versions we also checked if the number of weights was equal to
@@ -1182,6 +1203,21 @@ def spgl1(
     fbest = f
     xbest = x.copy()
     fold = f
+
+    # Initialize hybrid mode state
+    if hybrid_mode:
+        xabs = np.abs(x)
+        xnorm1_init = np.sum(xabs)
+        if abs(xnorm1_init - tau) / max(1.0, tau) < 1e-8:
+            hybrid_support = np.zeros(n, dtype=bool)  # Interior of L1 ball
+        else:
+            hybrid_support = xabs >= 1e-9  # Boundary
+        hybrid_H = None
+        hybrid_sqrt1 = None
+        hybrid_sqrt2 = None
+        flag_use_hessian = False
+    else:
+        flag_use_hessian = False
 
     # Initialize dual root-finding variables
     f_dual_max = -np.inf
@@ -1351,6 +1387,20 @@ def spgl1(
                     # Reset the function value history.
                     last_fv = np.full(10, -np.inf)
                     last_fv[1] = f
+                    fbest = f
+                    xbest = x.copy()
+
+                # Reset Hessian (always on tau update, not just decrease)
+                if hybrid_mode:
+                    hybrid_H = None
+                    flag_use_hessian = False
+
+                # Reset dual objective tracking
+                f_dual_max = -np.inf
+                gnorm_best = 0.0
+
+                # Reset status
+                stat = False
 
         # Too many iterations and not converged.
         if not stat and niters >= iter_lim:
@@ -1439,21 +1489,100 @@ def spgl1(
         rold = r.copy()
 
         while 1:
-            # Projected gradient step and linesearch.
-            (
-                f,
-                x,
-                r,
-                niter_line,
-                stepg,
-                lnerr,
-                time_project_curvy,
-                time_matprod_curvy,
-            ) = _spg_line_curvy(x, gstep * g, max(last_fv), A, b, project, weights, tau, mu)
-            time_project += time_project_curvy
-            time_matprod += time_matprod_curvy
-            nprodA += niter_line + 1
-            nline_tot += niter_line
+            # ===================================
+            # Try a quasi-Newton direction first
+            # ===================================
+            lnerr = True  # Assume failure; set to False if hybrid succeeds
+            if flag_use_hessian:
+                try:
+                    # Step 1. Get search direction
+                    if not np.any(hybrid_support):
+                        # Interior of crosspolytope
+                        d = lbfgs_hprod(hybrid_H, -g)
+                    else:
+                        d = -g.copy()
+
+                        # Project gradient onto the coefficient space
+                        d_trans = product_b(
+                            hybrid_signs * d[hybrid_support], 1,
+                            hybrid_sqrt1, hybrid_sqrt2
+                        )
+
+                        # If ||dTrans|| is tiny, direction is (near) orthogonal to the face
+                        if np.linalg.norm(d_trans, 2) <= 1e-10 * max(1.0, np.linalg.norm(d, 2)):
+                            if single_tau:
+                                stat = EXIT_OPTIMAL
+                            else:
+                                test_updatetau = True
+                        else:
+                            # Get quasi-Newton search direction
+                            d_quasi = lbfgs_hprod(hybrid_H, d_trans)
+
+                            # Convert to global domain
+                            d = np.zeros(n)
+                            d_support = hybrid_signs * product_b(
+                                d_quasi, 0, hybrid_sqrt1, hybrid_sqrt2
+                            )
+                            d[hybrid_support] = d_support
+
+                    if not stat:
+                        # Step 2. Determine first non-zero entry to hit zero
+                        s1 = ((d < 0) & (x > 0)) | ((d > 0) & (x < 0))
+                        if np.any(s1):
+                            gamma_step = -np.max(x[s1] / d[s1])
+                        else:
+                            gamma_step = np.inf
+
+                        start_time_matvec = time.time()
+                        w = A.matvec(d)
+                        time_matprod += time.time() - start_time_matvec
+                        nprodA += 1
+
+                        # Step 3. Compute the optimal step length beta
+                        enumerator = w @ r
+                        denominator = w @ w
+                        if mu > 0:
+                            enumerator = enumerator - mu * (x @ d)
+                            denominator = denominator + mu * (d @ d)
+
+                        beta = enumerator / denominator
+                        if beta <= 1e-11:
+                            pass  # lnerr stays True → fall through
+                        else:
+                            beta = min(beta, gamma_step)
+                            # Take the hybrid step
+                            x = xold + beta * d
+                            r = r - beta * w  # Avoid evaluating A*x
+                            f = (r @ r) / 2.0
+                            if mu > 0:
+                                f = f + (mu / 2.0) * (x @ x)
+                            stepg = beta
+                            nline_tot += 1
+
+                            # Reset function value history after successful hybrid step
+                            last_fv[:] = f
+                            lnerr = False
+                except Exception:
+                    lnerr = True
+
+            # ---------------------------------------------------------------
+            # Projected gradient step and linesearch (fallback or standard)
+            # ---------------------------------------------------------------
+            if lnerr:
+                (
+                    f,
+                    x,
+                    r,
+                    niter_line,
+                    stepg,
+                    lnerr,
+                    time_project_curvy,
+                    time_matprod_curvy,
+                ) = _spg_line_curvy(x, gstep * g, max(last_fv), A, b, project, weights, tau, mu)
+                time_project += time_project_curvy
+                time_matprod += time_matprod_curvy
+                nprodA += niter_line + 1
+                nline_tot += niter_line
             if nprodA + nprodAt > max_matvec:
                 stat = EXIT_MATVEC_LIMIT
                 break
@@ -1584,6 +1713,107 @@ def spgl1(
                     gstep = min(step_max, max(step_min, sts / sty))
             else:
                 gstep = min(step_max, gstep)
+
+            # ---------------------------------------------------------------
+            # Update Hessian approximation (hybrid mode)
+            # ---------------------------------------------------------------
+            if not np.isreal(x).all():
+                hybrid_mode = False
+            if hybrid_mode:
+                support_old = hybrid_support.copy()
+                absx = np.abs(x)
+                xnorm1_h = np.sum(absx)
+
+                # Step 1. Determine support
+                if abs(xnorm1_h - tau) / max(1.0, tau) > 1e-8:
+                    hybrid_support = np.zeros(n, dtype=bool)  # Interior
+                    n_support = n + 1
+                else:
+                    hybrid_support = absx > 1e-9
+                    n_support = int(np.sum(hybrid_support))
+
+                # Step 2. Check if Hessian should be updated
+                flag_update_hessian = (
+                    n_support > 1 and
+                    n_support <= m and
+                    niters > 1 and
+                    not lnerr and
+                    np.array_equal(hybrid_support, support_old) and
+                    np.array_equal(
+                        np.sign(x[hybrid_support]),
+                        np.sign(xold[hybrid_support])
+                    )
+                )
+
+                # Step 3. Check self-projection condition
+                if flag_update_hessian:
+                    if np.any(hybrid_support):
+                        # Boundary of crosspolytope
+                        d_chk = -g
+                        s1_chk = ((d_chk < 0) & (x > 0)) | ((d_chk > 0) & (x < 0))
+                        s2_chk = ((d_chk <= 0) & (x < 0)) | ((d_chk >= 0) & (x > 0))
+                        s3_chk = ~(s1_chk | s2_chk)
+
+                        sum1 = np.sum(np.abs(d_chk[s1_chk]))
+                        sum2 = np.sum(np.abs(d_chk[s2_chk]))
+                        sum3 = np.sum(np.abs(d_chk[s3_chk]))
+
+                        if sum1 > sum2 + sum3:
+                            flag_self_proj = False
+                        elif sum1 < sum2 + sum3:
+                            n_supp = np.sum(hybrid_support)
+                            if n_supp > 0:
+                                flag_self_proj = (
+                                    np.max(np.abs(d_chk[s3_chk]), initial=0) <=
+                                    (sum1 + sum2) / n_supp
+                                )
+                            else:
+                                flag_self_proj = False
+                        else:
+                            flag_self_proj = (sum3 == 0)
+                    else:
+                        # Interior of crosspolytope
+                        flag_self_proj = True
+
+                    if not flag_self_proj:
+                        flag_update_hessian = False
+
+                # Step 4. Reset or update Hessian approximation
+                if flag_update_hessian:
+                    if hybrid_H is None:
+                        if not np.any(hybrid_support):
+                            # Interior
+                            hybrid_H = lbfgs_init(n, lbfgs_hist, 1e-3)
+                        else:
+                            # Boundary
+                            hybrid_signs = np.sign(x[hybrid_support])
+                            hybrid_H = lbfgs_init(n_support - 1, lbfgs_hist, 1e-3)
+
+                    # Compute sqrt vectors if needed
+                    if np.any(hybrid_support):
+                        if hybrid_sqrt1 is None or len(hybrid_sqrt1) != n:
+                            hybrid_sqrt1, hybrid_sqrt2 = compute_sqrt_vectors(n)
+
+                    # Update Hessian approximation
+                    s_iter = x - xold
+                    if not np.any(hybrid_support):
+                        lbfgs_update(hybrid_H, 1, s_iter, gold, g)
+                    else:
+                        lbfgs_update(
+                            hybrid_H, 1,
+                            product_b(hybrid_signs * s_iter[hybrid_support], 1,
+                                      hybrid_sqrt1, hybrid_sqrt2),
+                            product_b(hybrid_signs * gold[hybrid_support], 1,
+                                      hybrid_sqrt1, hybrid_sqrt2),
+                            product_b(hybrid_signs * g[hybrid_support], 1,
+                                      hybrid_sqrt1, hybrid_sqrt2),
+                        )
+
+                    flag_use_hessian = True
+                else:
+                    flag_use_hessian = False
+                    hybrid_H = None
+
             break  # Leave while loop. This is done to allow stopping the
             # computations at any time within the loop if max_matvec is
             # reached. If this is not the case, the loop is stopped here.


### PR DESCRIPTION
Port MATLAB's hybrid mode (quasi-Newton acceleration) to Python:
- Rewrite lbfgs.py to match MATLAB's compact representation with damped BFGS updates (lbfgsinit, lbfgsupdate, lbfgshprod, lbfgsbprod)
- Integrate hybrid search direction into main solver loop with support set identification, self-projection checks, and automatic fallback to projected gradient
- Add hybrid_mode and lbfgs_hist parameters to spgl1()
- Reset Hessian on tau updates (matching MATLAB behavior)
- 180/186 tests pass (6 pre-existing failures, 0 regressions)