### PR TITLE
Add spg_group to __all__ exports

### DIFF
--- a/spgl1/__init__.py
+++ b/spgl1/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "spg_bpdn",
     "spg_lasso",
     "spg_mmv",
+    "spg_group",
 ]
 
 


### PR DESCRIPTION
The spg_group function was defined but not included in the public API exports list.