### PR TITLE
Fix test warnings

### DIFF
--- a/pytests/test_group_sparsity.py
+++ b/pytests/test_group_sparsity.py
@@ -282,7 +282,7 @@ class TestGroupSparseVsOctave:
 
         # Solutions should be similar (not identical due to solver paths)
         # Check objective values match
-        rnorm_oct = float(np.asarray(info_oct['rNorm']).flat[0])
+        rnorm_oct = np.asarray(info_oct['rNorm']).flatten()[0].item()
         assert abs(info_py['rnorm'] - rnorm_oct) < 1e-6, \
             f"Python rnorm={info_py['rnorm']}, Octave rnorm={rnorm_oct}"
 
@@ -316,7 +316,7 @@ class TestGroupSparseVsOctave:
         g_oct = result['outputs'][2].flatten()
         info_oct = result['outputs'][3]
 
-        rnorm_oct = float(np.asarray(info_oct['rNorm']).flat[0])
+        rnorm_oct = np.asarray(info_oct['rNorm']).flatten()[0].item()
 
         # Both solvers should produce reasonable solutions
         # Python converges to near-zero residual; Octave may take different path

--- a/pytests/test_mu_parameter.py
+++ b/pytests/test_mu_parameter.py
@@ -133,7 +133,7 @@ class TestMuConvergence:
 
         # Both should iterate
         assert info_py['niters'] > 0, "Python didn't iterate"
-        iter_mat = int(np.asarray(info_mat['iter']).flat[0])
+        iter_mat = np.asarray(info_mat['iter']).flatten()[0].item()
         assert iter_mat > 0, "MATLAB didn't iterate"
 
         # Both should find solutions with similar sparsity
@@ -169,7 +169,7 @@ class TestMuConvergence:
 
         # Get residual norms
         rnorm_py = info_py['rnorm']
-        rnorm_mat = float(np.asarray(info_mat['rNorm']).flat[0])
+        rnorm_mat = np.asarray(info_mat['rNorm']).flatten()[0].item()
 
         # With mu > 0, rNorm should be augmented residual:
         # rNorm = sqrt(||Ax-b||^2 + mu*||x||^2)
@@ -381,8 +381,8 @@ class TestFindLambdaStar:
         result = octave("findLambdaStar", z, w, tau, mu, nargout=2, timeout=10)
         assert result['success'], f"Octave failed: {result.get('error')}"
 
-        lambda_mat = float(result['outputs'][0])
-        obj_mat = float(result['outputs'][1])
+        lambda_mat = np.asarray(result['outputs'][0]).flatten()[0].item()
+        obj_mat = np.asarray(result['outputs'][1]).flatten()[0].item()
 
         # Compare results
         np.testing.assert_allclose(lambda_py, lambda_mat, rtol=1e-10,

--- a/pytests/test_octave_interface.py
+++ b/pytests/test_octave_interface.py
@@ -59,12 +59,12 @@ def test_spgl1_simple(octave, random_problem):
     # Check convergence - just verify we got a status code
     # Exit statuses: 1=root, 2=BP, 3=LS, 4=optimal, 5=maxIter, 6=linesearch,
     # 7=suboptimal BP, 8=maxMatvec, 9=maxTime, 10=inaccurate projection
-    stat = int(np.asarray(info_mat['stat']).flat[0])
+    stat = np.asarray(info_mat['stat']).flatten()[0].item()
     assert 1 <= stat <= 10, f"Invalid exit status: {stat}"
 
     # Just verify we got numerical results
     # (not testing convergence quality here, just interface)
-    rnorm = float(np.asarray(info_mat['rNorm']).flat[0])
+    rnorm = np.asarray(info_mat['rNorm']).flatten()[0].item()
     assert np.isfinite(rnorm), f"Residual is not finite: {rnorm}"
 
 

--- a/pytests/test_solvers_simple.py
+++ b/pytests/test_solvers_simple.py
@@ -75,7 +75,7 @@ class TestSolverBasics:
         assert info_py['niters'] > 0, "Python didn't iterate"
 
         # MATLAB should iterate
-        iter_mat = int(np.asarray(info_mat['iter']).flat[0])
+        iter_mat = np.asarray(info_mat['iter']).flatten()[0].item()
         assert iter_mat > 0, "MATLAB didn't iterate"
 
     def test_sparsity_promoted(self, octave, random_problem):
@@ -121,7 +121,7 @@ class TestNumericalBehavior:
         info_mat = result['outputs'][3]
 
         rnorm_py = info_py['rnorm']
-        rnorm_mat = float(np.asarray(info_mat['rNorm']).flat[0])
+        rnorm_mat = np.asarray(info_mat['rNorm']).flatten()[0].item()
 
         # Residuals should be in same order of magnitude (within 10x)
         ratio = max(rnorm_py, rnorm_mat) / (min(rnorm_py, rnorm_mat) + 1e-10)

--- a/spgl1/spgl1.py
+++ b/spgl1/spgl1.py
@@ -436,7 +436,7 @@ def _norm_l12_project(g, x, weights, tau):
 
     idx = xa < np.spacing(1)
     xc = oneprojector(xa, weights, tau)
-    xc = xc / xa
+    xc[~idx] = xc[~idx] / xa[~idx]
     xc[idx] = 0
     xx = spdiags(xc, 0, m, m) * xx
     return xx.flatten()


### PR DESCRIPTION
- Fix NumPy DeprecationWarning for array-to-scalar conversion by using .flatten()[0].item() pattern for extracting scalars from MATLAB arrays
- Fix RuntimeWarning divide-by-zero in _norm_l12_project by only dividing where xa is nonzero

All 207 tests now pass with 0 warnings.