### PR TITLE
Rename variables in productB.py to descriptive names

### DIFF
--- a/benchmarks/benchmark_micro.py
+++ b/benchmarks/benchmark_micro.py
@@ -158,7 +158,7 @@ def generate_test_data(size: ProblemSize, seed: int = 42) -> dict:
     step = 0.1
 
     # For productB
-    sqrt1, sqrt2 = compute_sqrt_vectors(n)
+    sqrt_recip, sqrt_ratio = compute_sqrt_vectors(n)
 
     # For group norms (g groups of size m/g each, assuming n divisible)
     g_groups = min(10, n // 10)  # Number of groups
@@ -181,8 +181,8 @@ def generate_test_data(size: ProblemSize, seed: int = 42) -> dict:
         "g2": g2,
         "p": p,
         "step": step,
-        "sqrt1": sqrt1,
-        "sqrt2": sqrt2,
+        "sqrt_recip": sqrt_recip,
+        "sqrt_ratio": sqrt_ratio,
         "g_groups": g_groups,
         "z": z,
         "w": w,
@@ -303,15 +303,15 @@ def bench_lbfgs_update(data: dict) -> tuple:
 
 def bench_product_b_forward(data: dict) -> tuple:
     """Benchmark productB forward mode."""
-    return (product_b, (data["x"], 0, data["sqrt1"], data["sqrt2"]))
+    return (product_b, (data["x"], 0, data["sqrt_recip"], data["sqrt_ratio"]))
 
 
 def bench_product_b_transpose(data: dict) -> tuple:
     """Benchmark productB transpose mode."""
     # Need d+1 dimensional input for transpose
     x_ext = np.concatenate([[0.0], data["x"]])
-    sqrt1, sqrt2 = compute_sqrt_vectors(data["n"])
-    return (product_b, (x_ext, 1, sqrt1, sqrt2))
+    sqrt_recip, sqrt_ratio = compute_sqrt_vectors(data["n"])
+    return (product_b, (x_ext, 1, sqrt_recip, sqrt_ratio))
 
 
 def bench_compute_sqrt_vectors(data: dict) -> tuple:

--- a/docs/VARIABLE_RENAMING_PLAN.md
+++ b/docs/VARIABLE_RENAMING_PLAN.md
@@ -1,0 +1,175 @@
+# SPGL1 Variable Renaming Plan
+
+This document tracks the systematic renaming of MATLAB-style variables to Python conventions.
+
+## Guiding Principles
+
+1. **No single-letter variables** - Every variable gets a descriptive name
+2. **snake_case** - All variables use Python naming conventions
+3. **Meaningful names** - Names should convey purpose, not just type
+4. **Preserve math notation in comments** - Reference original variable names in docstrings for academic paper alignment
+
+## PR Strategy
+
+Split into ~10 PRs to keep reviews manageable:
+
+### Code PRs (6-8)
+
+| PR | File(s) | Scope | Status |
+|----|---------|-------|--------|
+| 1 | `productB.py` | ~20 renames | Pending |
+| 2 | `lbfgs.py` - functions | Function params & locals | Pending |
+| 3 | `lbfgs.py` - LBFGSState | Class attributes | Pending |
+| 4 | `lsqr.py` - Part 1 | Lanczos vectors, rotations | Pending |
+| 5 | `lsqr.py` - Part 2 | Norms, tolerances, stopping | Pending |
+| 6 | `spgl1.py` - Core | Main loop, iterations, norms | Pending |
+| 7 | `spgl1.py` - Helpers | Projection/subproblem functions | Pending |
+| 8 | `spgl1.py` - API | Options/info dict keys (if needed) | Pending |
+
+### Test PRs (2-4)
+
+| PR | Scope | Status |
+|----|-------|--------|
+| 9 | Tests Part 1 | Pending |
+| 10 | Tests Part 2 | Pending |
+
+---
+
+## PR1: productB.py Renames
+
+### Current → Proposed
+
+| Current | Proposed | Rationale |
+|---------|----------|-----------|
+| `x` (input param) | `input_vector` | Generic input to transform |
+| `y` (output) | `output_vector` | Generic output from transform |
+| `d` (dimension) | `support_size` | Size of the support set |
+| `i` (loop index) | `idx` | Loop index |
+| `t` (accumulator) | `accumulator` | Running sum in transformation |
+| `xi` (element) | `input_element` | Single element being processed |
+| `sqrt1` | `sqrt_recip_coeffs` | sqrt(1/(i*(i+1))) coefficients |
+| `sqrt2` | `sqrt_ratio_coeffs` | sqrt(i/(i+1)) coefficients |
+| `transpose` | `is_transpose` | Boolean-like mode flag |
+
+### Notes
+- `sqrt1`/`sqrt2` are mathematical coefficients - names should reflect their formula
+- Alternative for `sqrt1`/`sqrt2`: `scale_coeffs_1`, `scale_coeffs_2` or keep as `sqrt_coeffs_a`, `sqrt_coeffs_b`
+
+---
+
+## PR2: lbfgs.py Functions
+
+### Function Parameters & Locals
+
+| Current | Proposed | Context |
+|---------|----------|---------|
+| `n` | `vector_size` | Dimension of problem |
+| `k` | `history_size` | L-BFGS memory parameter |
+| `H` | `lbfgs_state` | L-BFGS state object |
+| `g` | `gradient` | Gradient vector |
+| `p` | `direction` | Search direction |
+| `s` | `step_vector` | Step s = x_new - x_old |
+| `y` | `gradient_diff` | Gradient difference y = g_new - g_old |
+| `i` | `idx` | Loop index |
+
+---
+
+## PR3: lbfgs.py LBFGSState Class
+
+### Class Attributes
+
+| Current | Proposed | Rationale |
+|---------|----------|-----------|
+| `jNew` | `newest_index` | Index of most recent history entry |
+| `jOld` | `oldest_index` | Index of oldest history entry |
+| `jMax` | `max_history_index` | Maximum history index |
+| `S` | `step_history` | Matrix of stored steps |
+| `Y` | `gradient_diff_history` | Matrix of stored gradient diffs |
+| `r` | `scaling_vector` | Diagonal scaling |
+| `D` | `diagonal_matrix` | Diagonal of B_k |
+| `L` | `lower_triangular` | Lower triangular factor |
+| `M` | `middle_matrix` | Middle matrix in compact form |
+| `gamma` | `hessian_scaling` | Initial Hessian scaling |
+| `delta` | `damping_factor` | Damping parameter |
+| `STS` | `step_inner_products` | S^T * S matrix |
+| `ML` | `middle_lower` | Lower Cholesky factor of M |
+| `MU` | `middle_upper` | Upper Cholesky factor of M |
+| `valid` | `is_valid` | Whether state is usable |
+| `rank` | `effective_rank` | Current history rank |
+
+---
+
+## PR4-5: lsqr.py
+
+### Part 1: Lanczos & Rotation Variables
+
+| Current | Proposed | Context |
+|---------|----------|---------|
+| `m`, `n` | `num_rows`, `num_cols` | Matrix dimensions |
+| `u`, `v`, `w` | `left_vector`, `right_vector`, `work_vector` | Lanczos vectors |
+| `alfa`, `beta` | `alpha_coeff`, `beta_coeff` | Lanczos coefficients |
+| `rhobar`, `rho` | `rho_bar`, `rho_current` | Rotation values |
+| `phibar`, `phi` | `phi_bar`, `phi_current` | Rotation values |
+| `cs`, `sn` | `cosine`, `sine` | Givens rotation components |
+
+### Part 2: Norms & Tolerances
+
+| Current | Proposed | Context |
+|---------|----------|---------|
+| `anorm`, `acond` | `matrix_norm`, `condition_estimate` | Matrix properties |
+| `bnorm` | `rhs_norm` | Right-hand side norm |
+| `xnorm` | `solution_norm` | Solution norm |
+| `rnorm` | `residual_norm` | Residual norm |
+| `arnorm` | `gradient_norm` | A'*r norm (optimality) |
+| `atol`, `btol` | `abs_tolerance`, `rel_tolerance` | Convergence tolerances |
+| `itn` | `iteration` | Current iteration |
+| `istop` | `stop_reason` | Termination code |
+
+---
+
+## PR6-8: spgl1.py
+
+(To be detailed after PR1 feedback)
+
+### Preliminary Categories
+
+**Core Loop Variables:**
+- `x`, `r`, `g`, `f` → `solution`, `residual`, `gradient`, `objective`
+- `tau`, `sigma` → `constraint_radius`, `noise_level`
+- `niters` → `iteration_count`
+
+**Norm Variables:**
+- `rnorm`, `gnorm`, `xnorm` → `residual_norm`, `gradient_norm`, `solution_norm`
+
+**Step Variables:**
+- `d`, `s` → `search_direction`, `step`
+- `stepg` → `step_length`
+
+---
+
+## Open Questions
+
+1. **Greek letters in math**: Should `alpha`, `beta`, `gamma`, `delta`, `rho`, `tau`, `sigma` become descriptive names, or are they acceptable as spelled-out Greek?
+   - Proposal: Use descriptive names (`step_length` not `alpha`, `damping_factor` not `delta`)
+   - Exception: `tau` and `sigma` may stay as they're domain-specific SPGL1 terminology
+
+2. **Matrix convention**: MATLAB uses capitals for matrices. In Python:
+   - Proposal: Use `_matrix` suffix for clarity (`step_history` not `S`)
+
+3. **Loop indices**: `i`, `j`, `k` are ubiquitous
+   - Proposal: Use `idx`, `row_idx`, `col_idx`, or domain-specific names
+
+---
+
+## Progress Tracking
+
+- [ ] PR1: productB.py
+- [ ] PR2: lbfgs.py functions
+- [ ] PR3: lbfgs.py LBFGSState
+- [ ] PR4: lsqr.py Part 1
+- [ ] PR5: lsqr.py Part 2
+- [ ] PR6: spgl1.py Core
+- [ ] PR7: spgl1.py Helpers
+- [ ] PR8: spgl1.py API
+- [ ] PR9: Tests Part 1
+- [ ] PR10: Tests Part 2

--- a/pytests/test_hybrid_mode.py
+++ b/pytests/test_hybrid_mode.py
@@ -516,58 +516,58 @@ class TestProductB:
     """Test productB transformation."""
 
     def test_forward_dimensions(self):
-        """Forward: d -> d+1."""
-        d = 10
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
-        x = np.random.randn(d)
-        y = product_b(x, 0, sqrt1, sqrt2)
-        assert y.shape == (d + 1,)
-        assert np.all(np.isfinite(y))
+        """Forward: support_size -> support_size+1."""
+        support_size = 10
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
+        input_vec = np.random.randn(support_size)
+        output_vec = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
+        assert output_vec.shape == (support_size + 1,)
+        assert np.all(np.isfinite(output_vec))
 
     def test_transpose_dimensions(self):
-        """Transpose: d+1 -> d."""
-        d = 10
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
-        x = np.random.randn(d + 1)
-        y = product_b(x, 1, sqrt1, sqrt2)
-        assert y.shape == (d,)
-        assert np.all(np.isfinite(y))
+        """Transpose: support_size+1 -> support_size."""
+        support_size = 10
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
+        input_vec = np.random.randn(support_size + 1)
+        output_vec = product_b(input_vec, 1, sqrt_recip, sqrt_ratio)
+        assert output_vec.shape == (support_size,)
+        assert np.all(np.isfinite(output_vec))
 
     def test_adjoint_property(self):
         """<Bx, y> == <x, B'y> (adjoint property)."""
         np.random.seed(300)
-        d = 20
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 20
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        x = np.random.randn(d)
-        y = np.random.randn(d + 1)
+        input_vec = np.random.randn(support_size)
+        other_vec = np.random.randn(support_size + 1)
 
-        Bx = product_b(x, 0, sqrt1, sqrt2)
-        Bty = product_b(y, 1, sqrt1, sqrt2)
+        forward_result = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
+        transpose_result = product_b(other_vec, 1, sqrt_recip, sqrt_ratio)
 
-        lhs = Bx @ y
-        rhs = x @ Bty
+        lhs = forward_result @ other_vec
+        rhs = input_vec @ transpose_result
         np.testing.assert_allclose(lhs, rhs, rtol=1e-12)
 
     def test_orthogonality(self):
         """B'*B should be identity (orthogonal transformation)."""
         np.random.seed(301)
-        d = 15
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 15
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Build B'B explicitly via unit vectors
-        BtB = np.zeros((d, d))
-        for j in range(d):
-            ej = np.zeros(d)
-            ej[j] = 1.0
-            Bej = product_b(ej, 0, sqrt1, sqrt2)
-            for i in range(d):
-                ei = np.zeros(d)
-                ei[i] = 1.0
-                Bei = product_b(ei, 0, sqrt1, sqrt2)
-                BtB[i, j] = Bei @ Bej
+        btb_matrix = np.zeros((support_size, support_size))
+        for col_idx in range(support_size):
+            unit_col = np.zeros(support_size)
+            unit_col[col_idx] = 1.0
+            b_unit_col = product_b(unit_col, 0, sqrt_recip, sqrt_ratio)
+            for row_idx in range(support_size):
+                unit_row = np.zeros(support_size)
+                unit_row[row_idx] = 1.0
+                b_unit_row = product_b(unit_row, 0, sqrt_recip, sqrt_ratio)
+                btb_matrix[row_idx, col_idx] = b_unit_row @ b_unit_col
 
-        np.testing.assert_allclose(BtB, np.eye(d), atol=1e-13)
+        np.testing.assert_allclose(btb_matrix, np.eye(support_size), atol=1e-13)
 
 
 # =========================================================================

--- a/pytests/test_productB.py
+++ b/pytests/test_productB.py
@@ -14,139 +14,139 @@ class TestProductBBasics:
 
     def test_compute_sqrt_vectors(self):
         """Test sqrt vector computation."""
-        d = 5
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 5
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Check shapes
-        assert sqrt1.shape == (d,)
-        assert sqrt2.shape == (d,)
+        assert sqrt_recip.shape == (support_size,)
+        assert sqrt_ratio.shape == (support_size,)
 
-        # Check values manually for small d
-        # i=1: sqrt1[0] = sqrt(1/(1*2)) = sqrt(1/2)
-        assert np.abs(sqrt1[0] - np.sqrt(0.5)) < 1e-15
-        # i=1: sqrt2[0] = sqrt(1/2)
-        assert np.abs(sqrt2[0] - np.sqrt(0.5)) < 1e-15
+        # Check values manually for small support_size
+        # i=1: sqrt_recip[0] = sqrt(1/(1*2)) = sqrt(1/2)
+        assert np.abs(sqrt_recip[0] - np.sqrt(0.5)) < 1e-15
+        # i=1: sqrt_ratio[0] = sqrt(1/2)
+        assert np.abs(sqrt_ratio[0] - np.sqrt(0.5)) < 1e-15
 
-        # i=2: sqrt1[1] = sqrt(1/(2*3)) = sqrt(1/6)
-        assert np.abs(sqrt1[1] - np.sqrt(1.0/6.0)) < 1e-15
-        # i=2: sqrt2[1] = sqrt(2/3)
-        assert np.abs(sqrt2[1] - np.sqrt(2.0/3.0)) < 1e-15
+        # i=2: sqrt_recip[1] = sqrt(1/(2*3)) = sqrt(1/6)
+        assert np.abs(sqrt_recip[1] - np.sqrt(1.0/6.0)) < 1e-15
+        # i=2: sqrt_ratio[1] = sqrt(2/3)
+        assert np.abs(sqrt_ratio[1] - np.sqrt(2.0/3.0)) < 1e-15
 
     def test_forward_simple(self):
         """Test forward transformation on simple input."""
-        d = 5
-        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 5
+        input_vec = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        y = product_b(x, 0, sqrt1, sqrt2)
+        output_vec = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
 
         # Check dimensions
-        assert y.shape == (d + 1,)
-        assert np.all(np.isfinite(y))
+        assert output_vec.shape == (support_size + 1,)
+        assert np.all(np.isfinite(output_vec))
 
     def test_transpose_simple(self):
         """Test transpose transformation."""
-        d = 5
-        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 5
+        input_vec = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        y = product_b(x, 1, sqrt1, sqrt2)
+        output_vec = product_b(input_vec, 1, sqrt_recip, sqrt_ratio)
 
         # Check dimensions
-        assert y.shape == (d,)
-        assert np.all(np.isfinite(y))
+        assert output_vec.shape == (support_size,)
+        assert np.all(np.isfinite(output_vec))
 
     def test_forward_zeros(self):
         """Test forward mode with zero input."""
-        d = 10
-        x = np.zeros(d)
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 10
+        input_vec = np.zeros(support_size)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        y = product_b(x, 0, sqrt1, sqrt2)
+        output_vec = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
 
         # Should be all zeros
-        assert np.allclose(y, 0.0)
+        assert np.allclose(output_vec, 0.0)
 
     def test_transpose_zeros(self):
         """Test transpose mode with zero input."""
-        d = 10
-        x = np.zeros(d + 1)
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 10
+        input_vec = np.zeros(support_size + 1)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        y = product_b(x, 1, sqrt1, sqrt2)
+        output_vec = product_b(input_vec, 1, sqrt_recip, sqrt_ratio)
 
         # Should be all zeros
-        assert np.allclose(y, 0.0)
+        assert np.allclose(output_vec, 0.0)
 
     def test_dimensions_consistency(self):
         """Test dimension consistency of forward and transpose."""
-        for d in [1, 5, 10, 50, 100]:
-            sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        for support_size in [1, 5, 10, 50, 100]:
+            sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-            # Forward: d -> d+1
-            x = np.random.randn(d)
-            y = product_b(x, 0, sqrt1, sqrt2)
-            assert y.shape == (d + 1,)
+            # Forward: support_size -> support_size+1
+            input_vec = np.random.randn(support_size)
+            output_vec = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
+            assert output_vec.shape == (support_size + 1,)
 
-            # Transpose: d+1 -> d
-            x = np.random.randn(d + 1)
-            y = product_b(x, 1, sqrt1, sqrt2)
-            assert y.shape == (d,)
+            # Transpose: support_size+1 -> support_size
+            input_vec = np.random.randn(support_size + 1)
+            output_vec = product_b(input_vec, 1, sqrt_recip, sqrt_ratio)
+            assert output_vec.shape == (support_size,)
 
     def test_linearity_forward(self):
         """Test linearity of forward transformation."""
-        d = 10
-        x1 = np.random.randn(d)
-        x2 = np.random.randn(d)
+        support_size = 10
+        vec1 = np.random.randn(support_size)
+        vec2 = np.random.randn(support_size)
         alpha = 2.5
         beta = 1.3
 
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        # Compute product_b(alpha*x1 + beta*x2)
-        y_combined = product_b(alpha * x1 + beta * x2, 0, sqrt1, sqrt2)
+        # Compute product_b(alpha*vec1 + beta*vec2)
+        combined = product_b(alpha * vec1 + beta * vec2, 0, sqrt_recip, sqrt_ratio)
 
-        # Compute alpha*product_b(x1) + beta*product_b(x2)
-        y1 = product_b(x1, 0, sqrt1, sqrt2)
-        y2 = product_b(x2, 0, sqrt1, sqrt2)
-        y_separate = alpha * y1 + beta * y2
+        # Compute alpha*product_b(vec1) + beta*product_b(vec2)
+        out1 = product_b(vec1, 0, sqrt_recip, sqrt_ratio)
+        out2 = product_b(vec2, 0, sqrt_recip, sqrt_ratio)
+        separate = alpha * out1 + beta * out2
 
         # Should be equal (linear transformation)
-        assert np.allclose(y_combined, y_separate, rtol=1e-14)
+        assert np.allclose(combined, separate, rtol=1e-14)
 
     def test_linearity_transpose(self):
         """Test linearity of transpose transformation."""
-        d = 10
-        x1 = np.random.randn(d + 1)
-        x2 = np.random.randn(d + 1)
+        support_size = 10
+        vec1 = np.random.randn(support_size + 1)
+        vec2 = np.random.randn(support_size + 1)
         alpha = 1.7
         beta = 0.9
 
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-        y_combined = product_b(alpha * x1 + beta * x2, 1, sqrt1, sqrt2)
+        combined = product_b(alpha * vec1 + beta * vec2, 1, sqrt_recip, sqrt_ratio)
 
-        y1 = product_b(x1, 1, sqrt1, sqrt2)
-        y2 = product_b(x2, 1, sqrt1, sqrt2)
-        y_separate = alpha * y1 + beta * y2
+        out1 = product_b(vec1, 1, sqrt_recip, sqrt_ratio)
+        out2 = product_b(vec2, 1, sqrt_recip, sqrt_ratio)
+        separate = alpha * out1 + beta * out2
 
-        assert np.allclose(y_combined, y_separate, rtol=1e-14)
+        assert np.allclose(combined, separate, rtol=1e-14)
 
     def test_large_problem(self):
         """Test on larger support set."""
-        d = 500
-        x = np.random.randn(d)
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        support_size = 500
+        input_vec = np.random.randn(support_size)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Forward
-        y = product_b(x, 0, sqrt1, sqrt2)
-        assert y.shape == (d + 1,)
-        assert np.all(np.isfinite(y))
+        output_vec = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
+        assert output_vec.shape == (support_size + 1,)
+        assert np.all(np.isfinite(output_vec))
 
         # Transpose
-        y = product_b(y, 1, sqrt1, sqrt2)
-        assert y.shape == (d,)
-        assert np.all(np.isfinite(y))
+        output_vec = product_b(output_vec, 1, sqrt_recip, sqrt_ratio)
+        assert output_vec.shape == (support_size,)
+        assert np.all(np.isfinite(output_vec))
 
 
 @pytest.mark.skipif(not octave_available(), reason="Octave not available")
@@ -156,145 +156,145 @@ class TestProductBVsOctave:
     def test_forward_matches_matlab(self, octave, matlab_spgl_path):
         """Test forward mode matches MATLAB productBMex."""
         np.random.seed(900)
-        d = 20
-        x = np.random.randn(d)
+        support_size = 20
+        input_vec = np.random.randn(support_size)
 
         # Compute sqrt vectors
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Python
-        y_py = product_b(x, 0, sqrt1, sqrt2)
+        output_py = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
 
         # MATLAB (transpose=0 for forward mode)
-        result = octave("test_productBMex_wrapper", x, 0, sqrt1, sqrt2, nargout=1, timeout=10)
+        result = octave("test_productBMex_wrapper", input_vec, 0, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success'], f"Octave failed: {result.get('error')}"
-        y_matlab = result['outputs'][0].flatten()
+        output_matlab = result['outputs'][0].flatten()
 
         # Should match exactly (same algorithm)
-        assert np.allclose(y_py, y_matlab, rtol=1e-14, atol=1e-14), \
-            f"Max diff: {np.max(np.abs(y_py - y_matlab))}"
+        assert np.allclose(output_py, output_matlab, rtol=1e-14, atol=1e-14), \
+            f"Max diff: {np.max(np.abs(output_py - output_matlab))}"
 
     def test_transpose_matches_matlab(self, octave, matlab_spgl_path):
         """Test transpose mode matches MATLAB productBMex."""
         np.random.seed(901)
-        d = 20
-        x = np.random.randn(d + 1)
+        support_size = 20
+        input_vec = np.random.randn(support_size + 1)
 
         # Compute sqrt vectors
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Python
-        y_py = product_b(x, 1, sqrt1, sqrt2)
+        output_py = product_b(input_vec, 1, sqrt_recip, sqrt_ratio)
 
         # MATLAB (transpose=1 for transpose mode)
-        result = octave("test_productBMex_wrapper", x, 1, sqrt1, sqrt2, nargout=1, timeout=10)
+        result = octave("test_productBMex_wrapper", input_vec, 1, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success'], f"Octave failed: {result.get('error')}"
-        y_matlab = result['outputs'][0].flatten()
+        output_matlab = result['outputs'][0].flatten()
 
         # Should match exactly
-        assert np.allclose(y_py, y_matlab, rtol=1e-14, atol=1e-14), \
-            f"Max diff: {np.max(np.abs(y_py - y_matlab))}"
+        assert np.allclose(output_py, output_matlab, rtol=1e-14, atol=1e-14), \
+            f"Max diff: {np.max(np.abs(output_py - output_matlab))}"
 
     def test_forward_multiple_vectors(self, octave, matlab_spgl_path):
         """Test forward mode on multiple random vectors."""
         np.random.seed(902)
 
         for trial in range(5):
-            d = 10 + trial * 5  # d = 10, 15, 20, 25, 30
-            x = np.random.randn(d)
-            sqrt1, sqrt2 = compute_sqrt_vectors(d)
+            support_size = 10 + trial * 5  # support_size = 10, 15, 20, 25, 30
+            input_vec = np.random.randn(support_size)
+            sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-            y_py = product_b(x, 0, sqrt1, sqrt2)
+            output_py = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
 
-            result = octave("test_productBMex_wrapper", x, 0, sqrt1, sqrt2, nargout=1, timeout=10)
+            result = octave("test_productBMex_wrapper", input_vec, 0, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
             assert result['success']
-            y_matlab = result['outputs'][0].flatten()
+            output_matlab = result['outputs'][0].flatten()
 
-            assert np.allclose(y_py, y_matlab, rtol=1e-14, atol=1e-14), \
-                f"Trial {trial} failed, d={d}, max diff={np.max(np.abs(y_py - y_matlab))}"
+            assert np.allclose(output_py, output_matlab, rtol=1e-14, atol=1e-14), \
+                f"Trial {trial} failed, support_size={support_size}, max diff={np.max(np.abs(output_py - output_matlab))}"
 
     def test_transpose_multiple_vectors(self, octave, matlab_spgl_path):
         """Test transpose mode on multiple random vectors."""
         np.random.seed(903)
 
         for trial in range(5):
-            d = 10 + trial * 5
-            x = np.random.randn(d + 1)
-            sqrt1, sqrt2 = compute_sqrt_vectors(d)
+            support_size = 10 + trial * 5
+            input_vec = np.random.randn(support_size + 1)
+            sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
-            y_py = product_b(x, 1, sqrt1, sqrt2)
+            output_py = product_b(input_vec, 1, sqrt_recip, sqrt_ratio)
 
-            result = octave("test_productBMex_wrapper", x, 1, sqrt1, sqrt2, nargout=1, timeout=10)
+            result = octave("test_productBMex_wrapper", input_vec, 1, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
             assert result['success']
-            y_matlab = result['outputs'][0].flatten()
+            output_matlab = result['outputs'][0].flatten()
 
-            assert np.allclose(y_py, y_matlab, rtol=1e-14, atol=1e-14), \
-                f"Trial {trial} failed, d={d}"
+            assert np.allclose(output_py, output_matlab, rtol=1e-14, atol=1e-14), \
+                f"Trial {trial} failed, support_size={support_size}"
 
     def test_large_problem(self, octave, matlab_spgl_path):
         """Test on larger support set."""
         np.random.seed(904)
-        d = 100
-        x = np.random.randn(d)
+        support_size = 100
+        input_vec = np.random.randn(support_size)
 
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Python
-        y_py = product_b(x, 0, sqrt1, sqrt2)
+        output_py = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
 
         # MATLAB
-        result = octave("test_productBMex_wrapper", x, 0, sqrt1, sqrt2, nargout=1, timeout=10)
+        result = octave("test_productBMex_wrapper", input_vec, 0, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success']
-        y_matlab = result['outputs'][0].flatten()
+        output_matlab = result['outputs'][0].flatten()
 
-        assert np.allclose(y_py, y_matlab, rtol=1e-14, atol=1e-14)
+        assert np.allclose(output_py, output_matlab, rtol=1e-14, atol=1e-14)
 
     def test_round_trip(self, octave, matlab_spgl_path):
         """Test forward then transpose (not identity, but consistent with MATLAB)."""
         np.random.seed(905)
-        d = 30
-        x_orig = np.random.randn(d)
+        support_size = 30
+        input_orig = np.random.randn(support_size)
 
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Python: forward then transpose
-        y_py = product_b(x_orig, 0, sqrt1, sqrt2)
-        x_back_py = product_b(y_py, 1, sqrt1, sqrt2)
+        output_py = product_b(input_orig, 0, sqrt_recip, sqrt_ratio)
+        back_py = product_b(output_py, 1, sqrt_recip, sqrt_ratio)
 
         # MATLAB: forward then transpose
-        result = octave("test_productBMex_wrapper", x_orig, 0, sqrt1, sqrt2, nargout=1, timeout=10)
+        result = octave("test_productBMex_wrapper", input_orig, 0, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success']
-        y_mat = result['outputs'][0].flatten()
+        output_mat = result['outputs'][0].flatten()
 
-        result = octave("test_productBMex_wrapper", y_mat, 1, sqrt1, sqrt2, nargout=1, timeout=10)
+        result = octave("test_productBMex_wrapper", output_mat, 1, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success']
-        x_back_mat = result['outputs'][0].flatten()
+        back_mat = result['outputs'][0].flatten()
 
         # Round-trip should match MATLAB's round-trip
-        assert np.allclose(x_back_py, x_back_mat, rtol=1e-14, atol=1e-14)
+        assert np.allclose(back_py, back_mat, rtol=1e-14, atol=1e-14)
 
     def test_edge_case_d1(self, octave, matlab_spgl_path):
-        """Test edge case with d=1."""
+        """Test edge case with support_size=1."""
         np.random.seed(906)
-        d = 1
-        x = np.random.randn(d)
+        support_size = 1
+        input_vec = np.random.randn(support_size)
 
-        sqrt1, sqrt2 = compute_sqrt_vectors(d)
+        sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
 
         # Forward
-        y_py = product_b(x, 0, sqrt1, sqrt2)
-        result = octave("test_productBMex_wrapper", x, 0, sqrt1, sqrt2, nargout=1, timeout=10)
+        output_py = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)
+        result = octave("test_productBMex_wrapper", input_vec, 0, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success']
-        y_mat = result['outputs'][0].flatten()
-        assert np.allclose(y_py, y_mat, rtol=1e-14, atol=1e-14)
+        output_mat = result['outputs'][0].flatten()
+        assert np.allclose(output_py, output_mat, rtol=1e-14, atol=1e-14)
 
         # Transpose
-        x_t = np.random.randn(d + 1)
-        y_py = product_b(x_t, 1, sqrt1, sqrt2)
-        result = octave("test_productBMex_wrapper", x_t, 1, sqrt1, sqrt2, nargout=1, timeout=10)
+        input_trans = np.random.randn(support_size + 1)
+        output_py = product_b(input_trans, 1, sqrt_recip, sqrt_ratio)
+        result = octave("test_productBMex_wrapper", input_trans, 1, sqrt_recip, sqrt_ratio, nargout=1, timeout=10)
         assert result['success']
-        y_mat = result['outputs'][0].flatten()
-        assert np.allclose(y_py, y_mat, rtol=1e-14, atol=1e-14)
+        output_mat = result['outputs'][0].flatten()
+        assert np.allclose(output_py, output_mat, rtol=1e-14, atol=1e-14)
 
 
 if __name__ == "__main__":

--- a/spgl1/productB.py
+++ b/spgl1/productB.py
@@ -31,93 +31,100 @@ except ImportError:
 
 @jit(nopython=True)
 def _product_b_forward(
-    x: FloatArray,
-    sqrt1: FloatArray,
-    sqrt2: FloatArray,
+    input_vector: FloatArray,
+    sqrt_recip_coeffs: FloatArray,
+    sqrt_ratio_coeffs: FloatArray,
 ) -> FloatArray:
-    """Forward mode: d -> d+1 dimensions.
+    """Forward mode: support_size -> support_size+1 dimensions.
 
     Computes:
-        y[0] = t (accumulated value)
-        y[i] = t + sqrt2[i-1] * x[i-1] for i=1..d
+        output_vector[0] = neg_weighted_cumsum (negative weighted cumulative sum)
+        output_vector[idx] = neg_weighted_cumsum + sqrt_ratio_coeffs[idx-1] * input_vector[idx-1]
+            for idx=1..support_size
 
-    where t accumulates backward: t -= sqrt1[i] * x[i]
+    where neg_weighted_cumsum updates backward:
+        neg_weighted_cumsum -= sqrt_recip_coeffs[idx] * input_vector[idx]
 
     Parameters
     ----------
-    x : ndarray
-        Input vector (d,)
-    sqrt1 : ndarray
-        sqrt(1 / (i * (i+1))) for i=1..d
-    sqrt2 : ndarray
-        sqrt(i / (i+1)) for i=1..d
+    input_vector : ndarray
+        Input vector (support_size,)
+    sqrt_recip_coeffs : ndarray
+        sqrt(1 / (i * (i+1))) for i=1..support_size
+    sqrt_ratio_coeffs : ndarray
+        sqrt(i / (i+1)) for i=1..support_size
 
     Returns
     -------
-    y : ndarray
-        Transformed vector (d+1,)
+    output_vector : ndarray
+        Transformed vector (support_size+1,)
     """
-    d: int = len(x)
-    y: FloatArray = np.zeros(d + 1)
+    support_size: int = len(input_vector)
+    output_vector: FloatArray = np.zeros(support_size + 1)
 
-    t: float = 0.0
-    # Process in reverse order: d-1, d-2, ..., 1, 0
-    for i in range(d - 1, -1, -1):
-        xi: float = x[i]
-        y[i + 1] = t + sqrt2[i] * xi
-        t -= sqrt1[i] * xi
+    neg_weighted_cumsum: float = 0.0
+    # Process in reverse order: support_size-1, support_size-2, ..., 1, 0
+    for idx in range(support_size - 1, -1, -1):
+        input_element: float = input_vector[idx]
+        output_vector[idx + 1] = neg_weighted_cumsum + sqrt_ratio_coeffs[idx] * input_element
+        neg_weighted_cumsum -= sqrt_recip_coeffs[idx] * input_element
 
-    y[0] = t
-    return y
+    output_vector[0] = neg_weighted_cumsum
+    return output_vector
 
 
 @jit(nopython=True)
 def _product_b_transpose(
-    x: FloatArray,
-    sqrt1: FloatArray,
-    sqrt2: FloatArray,
+    input_vector: FloatArray,
+    sqrt_recip_coeffs: FloatArray,
+    sqrt_ratio_coeffs: FloatArray,
 ) -> FloatArray:
-    """Transpose mode: d+1 -> d dimensions.
+    """Transpose mode: support_size+1 -> support_size dimensions.
 
     Computes:
-        y[i] = sqrt1[i] * t + sqrt2[i] * x[i+1] for i=0..d-1
+        output_vector[idx] = sqrt_recip_coeffs[idx] * neg_cumsum
+                           + sqrt_ratio_coeffs[idx] * input_vector[idx+1]
+            for idx=0..support_size-1
 
-    where t accumulates forward: t -= x[i]
+    where neg_cumsum updates forward: neg_cumsum -= input_vector[idx]
 
     Parameters
     ----------
-    x : ndarray
-        Input vector (d+1,)
-    sqrt1 : ndarray
-        sqrt(1 / (i * (i+1))) for i=1..d
-    sqrt2 : ndarray
-        sqrt(i / (i+1)) for i=1..d
+    input_vector : ndarray
+        Input vector (support_size+1,)
+    sqrt_recip_coeffs : ndarray
+        sqrt(1 / (i * (i+1))) for i=1..support_size
+    sqrt_ratio_coeffs : ndarray
+        sqrt(i / (i+1)) for i=1..support_size
 
     Returns
     -------
-    y : ndarray
-        Transformed vector (d,)
+    output_vector : ndarray
+        Transformed vector (support_size,)
     """
-    d: int = len(x) - 1
-    y: FloatArray = np.zeros(d)
+    support_size: int = len(input_vector) - 1
+    output_vector: FloatArray = np.zeros(support_size)
 
-    t: float = 0.0
-    xi: float = x[0]
+    neg_cumsum: float = 0.0
+    input_element: float = input_vector[0]
 
-    # Process in forward order: 0, 1, 2, ..., d-1
-    for i in range(d):
-        t -= xi
-        xi = x[i + 1]
-        y[i] = sqrt1[i] * t + sqrt2[i] * xi
+    # Process in forward order: 0, 1, 2, ..., support_size-1
+    for idx in range(support_size):
+        neg_cumsum -= input_element
+        input_element = input_vector[idx + 1]
+        output_vector[idx] = (
+            sqrt_recip_coeffs[idx] * neg_cumsum
+            + sqrt_ratio_coeffs[idx] * input_element
+        )
 
-    return y
+    return output_vector
 
 
 def product_b(
-    x: FloatArray,
-    transpose: int,
-    sqrt1: FloatArray,
-    sqrt2: FloatArray,
+    input_vector: FloatArray,
+    is_transpose: int,
+    sqrt_recip_coeffs: FloatArray,
+    sqrt_ratio_coeffs: FloatArray,
 ) -> FloatArray:
     """Coordinate transformation for L-BFGS support set operations.
 
@@ -126,30 +133,30 @@ def product_b(
     - Global domain: Full vector with support set
     - Coefficient space: Transformed coordinates for quasi-Newton updates
 
-    The transformation uses precomputed values sqrt1 and sqrt2 that depend
-    on the support set size.
+    The transformation uses precomputed values sqrt_recip_coeffs and
+    sqrt_ratio_coeffs that depend on the support set size.
 
     Parameters
     ----------
-    x : ndarray
+    input_vector : ndarray
         Input vector
-        - If transpose=0 (forward): d-vector
-        - If transpose=1 (transpose): (d+1)-vector
-    transpose : int
+        - If is_transpose=0 (forward): support_size-vector
+        - If is_transpose=1 (transpose): (support_size+1)-vector
+    is_transpose : int
         Transformation mode:
-        - 0: Forward mode (d -> d+1)
-        - 1: Transpose mode (d+1 -> d)
-    sqrt1 : ndarray
-        Precomputed sqrt(1 / (i * (i+1))) for i=1..d
-    sqrt2 : ndarray
-        Precomputed sqrt(i / (i+1)) for i=1..d
+        - 0: Forward mode (support_size -> support_size+1)
+        - 1: Transpose mode (support_size+1 -> support_size)
+    sqrt_recip_coeffs : ndarray
+        Precomputed sqrt(1 / (i * (i+1))) for i=1..support_size
+    sqrt_ratio_coeffs : ndarray
+        Precomputed sqrt(i / (i+1)) for i=1..support_size
 
     Returns
     -------
-    y : ndarray
+    output_vector : ndarray
         Transformed vector
-        - If transpose=0: (d+1)-vector
-        - If transpose=1: d-vector
+        - If is_transpose=0: (support_size+1)-vector
+        - If is_transpose=1: support_size-vector
 
     Notes
     -----
@@ -162,39 +169,39 @@ def product_b(
 
     Examples
     --------
-    >>> d = 10
-    >>> x = np.random.randn(d)
-    >>> sqrt1, sqrt2 = compute_sqrt_vectors(d)
-    >>> y = product_b(x, 0, sqrt1, sqrt2)  # Forward
-    >>> x_back = product_b(y, 1, sqrt1, sqrt2)  # Transpose
+    >>> support_size = 10
+    >>> input_vec = np.random.randn(support_size)
+    >>> sqrt_recip, sqrt_ratio = compute_sqrt_vectors(support_size)
+    >>> output_vec = product_b(input_vec, 0, sqrt_recip, sqrt_ratio)  # Forward
+    >>> back_vec = product_b(output_vec, 1, sqrt_recip, sqrt_ratio)  # Transpose
     """
-    x = np.asarray(x, dtype=float)
-    sqrt1 = np.asarray(sqrt1, dtype=float)
-    sqrt2 = np.asarray(sqrt2, dtype=float)
+    input_vector = np.asarray(input_vector, dtype=float)
+    sqrt_recip_coeffs = np.asarray(sqrt_recip_coeffs, dtype=float)
+    sqrt_ratio_coeffs = np.asarray(sqrt_ratio_coeffs, dtype=float)
 
-    if transpose == 0:
-        return _product_b_forward(x, sqrt1, sqrt2)
+    if is_transpose == 0:
+        return _product_b_forward(input_vector, sqrt_recip_coeffs, sqrt_ratio_coeffs)
     else:
-        return _product_b_transpose(x, sqrt1, sqrt2)
+        return _product_b_transpose(input_vector, sqrt_recip_coeffs, sqrt_ratio_coeffs)
 
 
-def compute_sqrt_vectors(d: int) -> tuple[FloatArray, FloatArray]:
-    """Compute sqrt1 and sqrt2 vectors for productB transformation.
+def compute_sqrt_vectors(support_size: int) -> tuple[FloatArray, FloatArray]:
+    """Compute sqrt_recip_coeffs and sqrt_ratio_coeffs for productB transformation.
 
     These vectors are used by product_b() for efficient coordinate
-    transformations. They only depend on the support set size d.
+    transformations. They only depend on the support set size.
 
     Parameters
     ----------
-    d : int
+    support_size : int
         Support set size (number of active variables)
 
     Returns
     -------
-    sqrt1 : ndarray
-        sqrt(1 / (i * (i+1))) for i=1..d, shape (d,)
-    sqrt2 : ndarray
-        sqrt(i / (i+1)) for i=1..d, shape (d,)
+    sqrt_recip_coeffs : ndarray
+        sqrt(1 / (i * (i+1))) for i=1..support_size, shape (support_size,)
+    sqrt_ratio_coeffs : ndarray
+        sqrt(i / (i+1)) for i=1..support_size, shape (support_size,)
 
     Notes
     -----
@@ -207,13 +214,13 @@ def compute_sqrt_vectors(d: int) -> tuple[FloatArray, FloatArray]:
 
     Examples
     --------
-    >>> sqrt1, sqrt2 = compute_sqrt_vectors(5)
-    >>> sqrt1.shape
+    >>> sqrt_recip, sqrt_ratio = compute_sqrt_vectors(5)
+    >>> sqrt_recip.shape
     (5,)
-    >>> sqrt2.shape
+    >>> sqrt_ratio.shape
     (5,)
     """
-    i: FloatArray = np.arange(1, d + 1, dtype=float)
-    sqrt1: FloatArray = np.sqrt(1.0 / (i * (i + 1.0)))
-    sqrt2: FloatArray = np.sqrt(i / (i + 1.0))
-    return sqrt1, sqrt2
+    indices: FloatArray = np.arange(1, support_size + 1, dtype=float)
+    sqrt_recip_coeffs: FloatArray = np.sqrt(1.0 / (indices * (indices + 1.0)))
+    sqrt_ratio_coeffs: FloatArray = np.sqrt(indices / (indices + 1.0))
+    return sqrt_recip_coeffs, sqrt_ratio_coeffs

--- a/spgl1/spgl1.py
+++ b/spgl1/spgl1.py
@@ -1359,8 +1359,8 @@ def spgl1(
         else:
             hybrid_support = xabs >= 1e-9  # Boundary
         hybrid_H = None
-        hybrid_sqrt1 = None
-        hybrid_sqrt2 = None
+        hybrid_sqrt_recip = None
+        hybrid_sqrt_ratio = None
         flag_use_hessian = False
     else:
         flag_use_hessian = False
@@ -1661,8 +1661,8 @@ def spgl1(
                         d_trans = product_b(
                             hybrid_signs * d[hybrid_support],
                             1,
-                            hybrid_sqrt1,
-                            hybrid_sqrt2,
+                            hybrid_sqrt_recip,
+                            hybrid_sqrt_ratio,
                         )
 
                         # If ||dTrans|| is tiny, direction is (near) orthogonal to the face
@@ -1680,7 +1680,7 @@ def spgl1(
                             # Convert to global domain
                             d = np.zeros(n)
                             d_support = hybrid_signs * product_b(
-                                d_quasi, 0, hybrid_sqrt1, hybrid_sqrt2
+                                d_quasi, 0, hybrid_sqrt_recip, hybrid_sqrt_ratio
                             )
                             d[hybrid_support] = d_support
 
@@ -1950,8 +1950,8 @@ def spgl1(
 
                     # Compute sqrt vectors if needed
                     if np.any(hybrid_support):
-                        if hybrid_sqrt1 is None or len(hybrid_sqrt1) != n:
-                            hybrid_sqrt1, hybrid_sqrt2 = compute_sqrt_vectors(n)
+                        if hybrid_sqrt_recip is None or len(hybrid_sqrt_recip) != n:
+                            hybrid_sqrt_recip, hybrid_sqrt_ratio = compute_sqrt_vectors(n)
 
                     # Update Hessian approximation
                     s_iter = x - xold
@@ -1964,20 +1964,20 @@ def spgl1(
                             product_b(
                                 hybrid_signs * s_iter[hybrid_support],
                                 1,
-                                hybrid_sqrt1,
-                                hybrid_sqrt2,
+                                hybrid_sqrt_recip,
+                                hybrid_sqrt_ratio,
                             ),
                             product_b(
                                 hybrid_signs * gold[hybrid_support],
                                 1,
-                                hybrid_sqrt1,
-                                hybrid_sqrt2,
+                                hybrid_sqrt_recip,
+                                hybrid_sqrt_ratio,
                             ),
                             product_b(
                                 hybrid_signs * g[hybrid_support],
                                 1,
-                                hybrid_sqrt1,
-                                hybrid_sqrt2,
+                                hybrid_sqrt_recip,
+                                hybrid_sqrt_ratio,
                             ),
                         )
 


### PR DESCRIPTION
Replace single-letter and cryptic variable names with descriptive ones:
- x, y -> input_vector, output_vector
- d -> support_size
- i -> idx
- t -> neg_weighted_cumsum (forward) / neg_cumsum (transpose)
- xi -> input_element
- sqrt1 -> sqrt_recip_coeffs (sqrt of reciprocal formula)
- sqrt2 -> sqrt_ratio_coeffs (sqrt of ratio formula)

Also update all callers:
- spgl1.py: hybrid_sqrt1/2 -> hybrid_sqrt_recip/ratio
- benchmark_micro.py: sqrt1/2 -> sqrt_recip/ratio
- test_productB.py: Updated all test variables
- test_hybrid_mode.py: Updated TestProductB class

Add docs/VARIABLE_RENAMING_PLAN.md tracking the full renaming effort.

All 207 tests pass.