### PR TITLE
Fix ComplexWarning by removing incorrect float() casts

### DIFF
--- a/spgl1/spgl1.py
+++ b/spgl1/spgl1.py
@@ -1393,10 +1393,10 @@ def spgl1(
             rnorm = float(np.sqrt(2.0 * f))
 
         # Compute dual objective
-        rtr = float(np.dot(np.conj(r), r))
+        rtr = np.dot(np.conj(r), r).real
         if mu == 0:
             # Classic method: f_dual = r'*b - tau*||g|| - ||r||^2/2
-            f_dual = float(np.dot(np.conj(r), b)) - tau * gnorm - rtr / 2.0
+            f_dual = np.dot(np.conj(r), b) - tau * gnorm - rtr / 2.0
         else:
             # For mu > 0, use findLambdaStar for proper dual computation
             # Compute z = |mu*x - g| = |A'*r| (since g = -A'*r + mu*x)
@@ -1409,7 +1409,7 @@ def spgl1(
             else:
                 weights_full = weights
             obj_value, _ = _find_lambda_star(z, weights_full, tau, mu)
-            f_dual = float(np.dot(np.conj(r), b)) - rtr / 2.0 - obj_value
+            f_dual = np.dot(np.conj(r), b) - rtr / 2.0 - obj_value
 
         # Track best dual objective
         if f_dual > f_dual_max:
@@ -1418,7 +1418,7 @@ def spgl1(
         else:
             f_dual = f_dual_max
 
-        gap = float(np.dot(np.conj(r), r - b)) + tau * gnorm
+        gap = np.dot(np.conj(r), r - b) + tau * gnorm
         rgap = abs(gap) / max(1.0, f)
         aerror1 = rnorm - sigma
         aerror2 = f - sigma**2.0 / 2.0
@@ -1756,7 +1756,7 @@ def spgl1(
                 start_time_project = time.time()
                 dx = project(x - gstep * g, weights, tau) - x
                 time_project += time.time() - start_time_project
-                gtd = float(np.dot(np.conj(g), dx))
+                gtd = np.dot(np.conj(g), dx)
                 f, x, r, niter_line, lnerr, time_matprod_line = _spg_line(
                     f, x, dx, gtd, max(last_fv), A, b, mu
                 )
@@ -1866,8 +1866,8 @@ def spgl1(
                 nprodAt += 1
                 s = x - xold
                 y = g - gold
-                sts = float(np.dot(np.conj(s), s))
-                sty = float(np.dot(np.conj(s), y))
+                sts = np.dot(np.conj(s), s).real
+                sty = np.dot(np.conj(s), y)
                 if sty <= 0:
                     gstep = step_max
                 else:


### PR DESCRIPTION
The typing PR introduced float() casts that caused warnings when processing complex-valued data. Fixed by:

- np.dot(np.conj(x), x) -> use .real (self inner product is always real)
- np.dot(np.conj(x), y) -> remove float() cast (may be complex, let Python handle it)

Changes:
- rtr, sts: use .real for self inner products
- f_dual, gap, gtd, sty: remove float() to preserve complex values

All 207 tests pass with 0 warnings.