### PR TITLE
Fix complex dot product bugs: add np.conj() to match MATLAB x'*x

### DIFF
--- a/pytests/test_mu_parameter.py
+++ b/pytests/test_mu_parameter.py
@@ -32,8 +32,11 @@ class TestMuBasics:
 
         # Check that the augmented residual norm is reported correctly
         # For mu > 0, rnorm should be sqrt(||r||^2 + mu*||x||^2)
+        # Use np.conj() to handle complex inputs correctly (matches MATLAB x'*x)
         r_actual = b - A @ x_py
-        expected_rnorm = np.sqrt(np.dot(r_actual, r_actual) + mu * np.dot(x_py, x_py))
+        expected_rnorm = np.sqrt(
+            np.real(np.dot(np.conj(r_actual), r_actual) + mu * np.dot(np.conj(x_py), x_py))
+        )
         np.testing.assert_allclose(info_py['rnorm'], expected_rnorm, rtol=1e-6, atol=1e-9)
 
     def test_mu_zero_equals_nomu(self, octave, random_problem):
@@ -173,10 +176,13 @@ class TestMuConvergence:
 
         # With mu > 0, rNorm should be augmented residual:
         # rNorm = sqrt(||Ax-b||^2 + mu*||x||^2)
+        # Use np.conj() to handle complex inputs correctly (matches MATLAB x'*x)
 
         # Compute augmented residual for Python
         r_actual_py = b - A @ x_py
-        aug_rnorm_py = np.sqrt(np.dot(r_actual_py, r_actual_py) + mu * np.dot(x_py, x_py))
+        aug_rnorm_py = np.sqrt(
+            np.real(np.dot(np.conj(r_actual_py), r_actual_py) + mu * np.dot(np.conj(x_py), x_py))
+        )
 
         # Python's reported rNorm should match augmented residual
         np.testing.assert_allclose(rnorm_py, aug_rnorm_py, rtol=1e-6, atol=1e-9)
@@ -201,8 +207,11 @@ class TestMuObjective:
         x_py, r_py, g_py, info_py = spgl1(A, b, tau=0, sigma=sigma, mu=mu)
 
         # Manually compute objective
+        # Use np.conj() to handle complex inputs correctly (matches MATLAB x'*x)
         r_actual = b - A @ x_py
-        f_expected = 0.5 * np.dot(r_actual, r_actual) + 0.5 * mu * np.dot(x_py, x_py)
+        f_expected = 0.5 * np.real(
+            np.dot(np.conj(r_actual), r_actual) + mu * np.dot(np.conj(x_py), x_py)
+        )
 
         # Python should have computed this correctly internally
         # (We can't directly access f, but we can verify via residual norm)
@@ -389,6 +398,134 @@ class TestFindLambdaStar:
                                    err_msg="lambda_star differs from MATLAB")
         np.testing.assert_allclose(obj_py, obj_mat, rtol=1e-10,
                                    err_msg="objective differs from MATLAB")
+
+
+class TestMuComplexData:
+    """Test mu parameter with complex-valued data.
+
+    These tests verify that the dot product computations use np.conj()
+    correctly to match MATLAB's x'*x (conjugate transpose) behavior.
+    Without np.conj(), dot products of complex vectors would produce
+    complex results instead of real values.
+    """
+
+    def test_mu_complex_objective_is_real(self):
+        """Test that objective function is real for complex data with mu > 0.
+
+        This is a regression test for a bug where np.dot(x, x) was used instead
+        of np.dot(np.conj(x), x). In MATLAB, x'*x automatically conjugates,
+        giving a real result. The Python port must explicitly use np.conj().
+        """
+        from spgl1.spgl1 import spgl1
+
+        np.random.seed(500)
+        m, n = 30, 60
+
+        # Create complex-valued problem
+        A_real = np.random.randn(m, n)
+        A_imag = np.random.randn(m, n)
+        A = A_real + 1j * A_imag
+
+        x_true = np.zeros(n, dtype=complex)
+        k = 5
+        idx = np.random.choice(n, k, replace=False)
+        x_true[idx] = np.random.randn(k) + 1j * np.random.randn(k)
+
+        b = A @ x_true + 0.01 * (np.random.randn(m) + 1j * np.random.randn(m))
+
+        sigma = 0.1 * np.linalg.norm(b)
+        mu = 0.5
+
+        # Run solver
+        x_py, r_py, g_py, info_py = spgl1(A, b, tau=0, sigma=sigma, mu=mu)
+
+        # Verify solution is finite
+        assert np.all(np.isfinite(x_py)), "Solution contains non-finite values"
+
+        # Verify rnorm is real (not complex)
+        assert np.isreal(info_py['rnorm']), "rnorm should be real"
+
+        # Manually verify the augmented residual norm calculation is real
+        r_actual = b - A @ x_py
+        aug_rnorm_squared = np.dot(np.conj(r_actual), r_actual) + mu * np.dot(np.conj(x_py), x_py)
+        assert np.isreal(aug_rnorm_squared) or np.abs(np.imag(aug_rnorm_squared)) < 1e-10, \
+            f"Augmented rnorm^2 should be real, got imaginary part: {np.imag(aug_rnorm_squared)}"
+
+    def test_mu_complex_matches_manual_computation(self):
+        """Test that solver's rnorm matches manual computation for complex data."""
+        from spgl1.spgl1 import spgl1
+
+        np.random.seed(501)
+        m, n = 20, 40
+
+        # Create complex-valued problem
+        A = np.random.randn(m, n) + 1j * np.random.randn(m, n)
+        x_true = np.zeros(n, dtype=complex)
+        x_true[:3] = [1+1j, 2-1j, -1+2j]
+        b = A @ x_true + 0.01 * (np.random.randn(m) + 1j * np.random.randn(m))
+
+        sigma = 0.2 * np.linalg.norm(b)
+        mu = 0.25
+
+        x_py, r_py, g_py, info_py = spgl1(A, b, tau=0, sigma=sigma, mu=mu)
+
+        # Compute expected rnorm using correct formula with np.conj()
+        r_actual = b - A @ x_py
+        expected_rnorm = np.sqrt(
+            np.real(np.dot(np.conj(r_actual), r_actual) + mu * np.dot(np.conj(x_py), x_py))
+        )
+
+        np.testing.assert_allclose(
+            info_py['rnorm'], expected_rnorm, rtol=1e-6, atol=1e-9,
+            err_msg="Solver rnorm doesn't match manual computation for complex data"
+        )
+
+    @pytest.mark.matlab
+    def test_mu_complex_matches_matlab(self, octave):
+        """Test that Python results match MATLAB for complex data with mu > 0."""
+        from spgl1.spgl1 import spgl1
+
+        np.random.seed(502)
+        m, n = 25, 50
+
+        # Create complex-valued problem
+        A = np.random.randn(m, n) + 1j * np.random.randn(m, n)
+        x_true = np.zeros(n, dtype=complex)
+        x_true[:4] = [1+0.5j, -1+1j, 0.5-0.5j, 2+0j]
+        b = A @ x_true + 0.02 * (np.random.randn(m) + 1j * np.random.randn(m))
+
+        sigma = 0.15 * np.linalg.norm(b)
+        mu = 0.3
+
+        # Python version
+        x_py, r_py, g_py, info_py = spgl1(A, b, tau=0, sigma=sigma, mu=mu)
+
+        # MATLAB version
+        opts_result = octave("spgSetParms", "mu", mu, nargout=1, timeout=10)
+        assert opts_result['success'], f"Failed to set MATLAB options: {opts_result.get('error')}"
+        opts = opts_result['outputs'][0]
+
+        result = octave("spgl1", A, b, 0.0, sigma, np.array([]), opts, nargout=4, timeout=30)
+        assert result['success'], f"MATLAB spgl1 failed: {result.get('error')}"
+
+        x_mat = result['outputs'][0].flatten()
+        info_mat = result['outputs'][3]
+        rnorm_mat = np.asarray(info_mat['rNorm']).flatten()[0].item()
+
+        # Compare residual norms
+        # Note: Complex problems with mu > 0 may converge to different local minima
+        # so we use a looser tolerance here
+        rnorm_ratio = max(info_py['rnorm'], rnorm_mat) / (min(info_py['rnorm'], rnorm_mat) + 1e-10)
+        assert rnorm_ratio < 10.0, \
+            f"Complex mu>0: rnorms differ too much - Python: {info_py['rnorm']}, MATLAB: {rnorm_mat}"
+
+        # Solutions should be correlated
+        if np.linalg.norm(x_py) > 1e-6 and np.linalg.norm(x_mat) > 1e-6:
+            x_py_norm = x_py / np.linalg.norm(x_py)
+            x_mat_norm = x_mat / np.linalg.norm(x_mat)
+            correlation = np.abs(np.dot(np.conj(x_py_norm), x_mat_norm))
+            assert correlation > 0.5, \
+                f"Complex mu>0: Solutions not well correlated ({correlation})"
 
 
 if __name__ == "__main__":

--- a/spgl1/spgl1.py
+++ b/spgl1/spgl1.py
@@ -1339,7 +1339,7 @@ def spgl1(
     time_matprod += time.time() - start_time_matvec
     f = float(np.linalg.norm(r) ** 2 / 2.0)
     if mu > 0:
-        f = f + (mu / 2.0) * float(np.dot(x, x))
+        f = f + (mu / 2.0) * float(np.real(np.dot(np.conj(x), x)))
         g = g + mu * x
     nprodA += 1
     nprodAt += 1
@@ -1393,10 +1393,11 @@ def spgl1(
             rnorm = float(np.sqrt(2.0 * f))
 
         # Compute dual objective
-        rtr = float(np.dot(np.conj(r), r))
+        # Use np.real() to handle tiny imaginary residuals from floating-point arithmetic
+        rtr = float(np.real(np.dot(np.conj(r), r)))
         if mu == 0:
             # Classic method: f_dual = r'*b - tau*||g|| - ||r||^2/2
-            f_dual = float(np.dot(np.conj(r), b)) - tau * gnorm - rtr / 2.0
+            f_dual = float(np.real(np.dot(np.conj(r), b))) - tau * gnorm - rtr / 2.0
         else:
             # For mu > 0, use findLambdaStar for proper dual computation
             # Compute z = |mu*x - g| = |A'*r| (since g = -A'*r + mu*x)
@@ -1409,7 +1410,7 @@ def spgl1(
             else:
                 weights_full = weights
             obj_value, _ = _find_lambda_star(z, weights_full, tau, mu)
-            f_dual = float(np.dot(np.conj(r), b)) - rtr / 2.0 - obj_value
+            f_dual = float(np.real(np.dot(np.conj(r), b))) - rtr / 2.0 - obj_value
 
         # Track best dual objective
         if f_dual > f_dual_max:
@@ -1418,7 +1419,7 @@ def spgl1(
         else:
             f_dual = f_dual_max
 
-        gap = float(np.dot(np.conj(r), r - b)) + tau * gnorm
+        gap = float(np.real(np.dot(np.conj(r), r - b))) + tau * gnorm
         rgap = abs(gap) / max(1.0, f)
         aerror1 = rnorm - sigma
         aerror2 = f - sigma**2.0 / 2.0
@@ -1492,7 +1493,7 @@ def spgl1(
                     ratio = 0.0
 
                 # Dual objective determines candidate tau values
-                aerror_dual = float(np.dot(np.conj(b), r)) - tau * gnorm - rnorm * sigma
+                aerror_dual = float(np.real(np.dot(np.conj(b), r))) - tau * gnorm - rnorm * sigma
                 tau_new = max(tau, tau + aerror_dual / gnorm)
 
                 # Check optimality
@@ -1534,7 +1535,7 @@ def spgl1(
 
                     f = float(np.linalg.norm(r) ** 2 / 2.0)
                     if mu > 0:
-                        f = f + (mu / 2.0) * float(np.dot(x, x))
+                        f = f + (mu / 2.0) * float(np.real(np.dot(np.conj(x), x)))
                         g = g + mu * x
                     nprodA += 1
                     nprodAt += 1
@@ -1756,7 +1757,7 @@ def spgl1(
                 start_time_project = time.time()
                 dx = project(x - gstep * g, weights, tau) - x
                 time_project += time.time() - start_time_project
-                gtd = float(np.dot(np.conj(g), dx))
+                gtd = float(np.real(np.dot(np.conj(g), dx)))
                 f, x, r, niter_line, lnerr, time_matprod_line = _spg_line(
                     f, x, dx, gtd, max(last_fv), A, b, mu
                 )
@@ -1866,8 +1867,8 @@ def spgl1(
                 nprodAt += 1
                 s = x - xold
                 y = g - gold
-                sts = float(np.dot(np.conj(s), s))
-                sty = float(np.dot(np.conj(s), y))
+                sts = float(np.real(np.dot(np.conj(s), s)))
+                sty = float(np.real(np.dot(np.conj(s), y)))
                 if sty <= 0:
                     gstep = step_max
                 else:
@@ -2020,7 +2021,9 @@ def spgl1(
         if mu == 0:
             rnorm = float(np.linalg.norm(r))
         else:
-            rnorm = float(np.sqrt(np.dot(r, r) + mu * np.dot(x, x)))
+            rnorm = float(
+                np.sqrt(np.real(np.dot(np.conj(r), r) + mu * np.dot(np.conj(x), x)))
+            )
         nprodA += 1
         nprodAt += 1
 


### PR DESCRIPTION
The original Python port incorrectly translated MATLAB's x'*x (conjugate transpose times x) to np.dot(x, x), which doesn't conjugate. For complex data, this produces complex results instead of real values.

Fixed 3 source code bugs in spgl1.py:
- Line 1342: f = f + (mu/2) * np.dot(x, x) -> np.dot(np.conj(x), x)
- Line 1537: Same fix in tau update section
- Line 2023: Fixed both np.dot(r, r) and np.dot(x, x) in rnorm computation

Also added np.real() to 8 expressions that are mathematically real but may have tiny imaginary residuals from floating-point arithmetic:
- rtr, f_dual, gap, aerror_dual, gtd, sts, sty computations

Fixed corresponding bugs in test_mu_parameter.py where tests computed expected values using the same incorrect formula.

Added regression tests (TestMuComplexData) that would have caught these bugs:
- test_mu_complex_objective_is_real: Verifies rnorm is real
- test_mu_complex_matches_manual_computation: Verifies formula
- test_mu_complex_matches_matlab: Compares with MATLAB for complex data